### PR TITLE
Fix carousel indicator sync

### DIFF
--- a/app/src/main/java/com/example/jellyfinandroid/MainActivity.kt
+++ b/app/src/main/java/com/example/jellyfinandroid/MainActivity.kt
@@ -1314,8 +1314,13 @@ fun RecentlyAddedCarousel(
     val carouselState = rememberCarouselState { items.size }
     var currentItem by rememberSaveable { mutableStateOf(0) }
 
-    // For Material 3 carousel, we'll manually track the current item
-    // The carousel state doesn't have firstVisibleItemIndex like LazyListState
+    // Observe carousel scroll state and update the current item
+    LaunchedEffect(carouselState) {
+        snapshotFlow { carouselState.firstVisibleItemIndex }
+            .collect { index ->
+                currentItem = index
+            }
+    }
 
     Column(modifier = modifier) {
         HorizontalUncontainedCarousel(


### PR DESCRIPTION
## Summary
- watch carousel scroll state in RecentlyAddedCarousel
- update the current item index so page indicators respond to scrolling

## Testing
- `./gradlew lintDebug testDebugUnitTest --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868c8d8baec8327a0f4b7ace7066a35

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The current item indicator in the carousel now updates automatically as you scroll, providing a more responsive and accurate UI experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->