### PR TITLE
Remove obsolete Kotlin version property

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,4 +21,3 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-kotlin.version=2.0.0


### PR DESCRIPTION
## Summary
- delete the `kotlin.version` setting from `gradle.properties`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868c8d9134c8327a0d7e6138c2ffa58

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the explicit Kotlin version setting from configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->