### PR TITLE
Conditional HTTP logging for debug builds

### DIFF
--- a/app/src/main/java/com/example/jellyfinandroid/di/NetworkModule.kt
+++ b/app/src/main/java/com/example/jellyfinandroid/di/NetworkModule.kt
@@ -24,15 +24,13 @@ object NetworkModule {
     @Provides
     @Singleton
     fun provideOkHttpClient(): OkHttpClient {
-        val builder = OkHttpClient.Builder()
-
-        if (BuildConfig.DEBUG) {
-            builder.addInterceptor(HttpLoggingInterceptor().apply {
-                level = HttpLoggingInterceptor.Level.BODY
-            })
+        return OkHttpClient.Builder().apply {
+            if (BuildConfig.DEBUG) {
+                addInterceptor(HttpLoggingInterceptor().apply {
+                    level = HttpLoggingInterceptor.Level.BODY
+                })
+            }
         }
-
-        return builder
             .connectionPool(okhttp3.ConnectionPool(5, 5, TimeUnit.MINUTES))
             .connectTimeout(30, TimeUnit.SECONDS)
             .readTimeout(30, TimeUnit.SECONDS)


### PR DESCRIPTION
## Summary
- only attach HTTP logging interceptor in debug builds
- import `BuildConfig`

## Testing
- `./gradlew testDebugUnitTest lintDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868c8d939f8832799515343eaf96dcd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved network logging behavior so that detailed HTTP logs are only enabled in debug builds, reducing unnecessary logging in production.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->