### PR TITLE
Enable season to episode navigation

### DIFF
--- a/app/src/main/java/com/example/jellyfinandroid/MainActivity.kt
+++ b/app/src/main/java/com/example/jellyfinandroid/MainActivity.kt
@@ -36,6 +36,7 @@ import com.example.jellyfinandroid.ui.screens.QuickConnectScreen
 import com.example.jellyfinandroid.ui.screens.StuffScreen
 import com.example.jellyfinandroid.ui.screens.TVSeasonScreen
 import com.example.jellyfinandroid.ui.screens.TVShowsScreen
+import com.example.jellyfinandroid.ui.screens.TVEpisodesScreen
 import com.example.jellyfinandroid.ui.theme.JellyfinAndroidTheme
 import com.example.jellyfinandroid.ui.viewmodel.MainAppViewModel
 import com.example.jellyfinandroid.ui.viewmodel.ServerConnectionViewModel
@@ -117,6 +118,8 @@ fun JellyfinAndroidApp() {
         // Navigation state for TV Season screen
         var selectedSeriesId by rememberSaveable { mutableStateOf<String?>(null) }
         var showTVSeasonScreen by rememberSaveable { mutableStateOf(false) }
+        var selectedSeasonId by rememberSaveable { mutableStateOf<String?>(null) }
+        var showTVEpisodeScreen by rememberSaveable { mutableStateOf(false) }
 
         NavigationSuiteScaffold(
             navigationSuiteItems = {
@@ -178,24 +181,42 @@ fun JellyfinAndroidApp() {
                         )
                     }
                     AppDestinations.TV_SHOWS -> {
-                        if (showTVSeasonScreen && selectedSeriesId != null) {
-                            TVSeasonScreen(
-                                seriesId = selectedSeriesId!!,
-                                onBackClick = {
-                                    showTVSeasonScreen = false
-                                    selectedSeriesId = null
-                                },
-                                getImageUrl = { item -> mainViewModel.getImageUrl(item) },
-                                modifier = Modifier.padding(innerPadding)
-                            )
-                        } else {
-                            TVShowsScreen(
-                                onTVShowClick = { seriesId ->
-                                    selectedSeriesId = seriesId
-                                    showTVSeasonScreen = true
-                                },
-                                modifier = Modifier.padding(innerPadding)
-                            )
+                        when {
+                            showTVEpisodeScreen && selectedSeasonId != null -> {
+                                TVEpisodesScreen(
+                                    seasonId = selectedSeasonId!!,
+                                    onBackClick = {
+                                        showTVEpisodeScreen = false
+                                        selectedSeasonId = null
+                                    },
+                                    getImageUrl = { item -> mainViewModel.getImageUrl(item) },
+                                    modifier = Modifier.padding(innerPadding)
+                                )
+                            }
+                            showTVSeasonScreen && selectedSeriesId != null -> {
+                                TVSeasonScreen(
+                                    seriesId = selectedSeriesId!!,
+                                    onBackClick = {
+                                        showTVSeasonScreen = false
+                                        selectedSeriesId = null
+                                    },
+                                    getImageUrl = { item -> mainViewModel.getImageUrl(item) },
+                                    onSeasonClick = { seasonId ->
+                                        selectedSeasonId = seasonId
+                                        showTVEpisodeScreen = true
+                                    },
+                                    modifier = Modifier.padding(innerPadding)
+                                )
+                            }
+                            else -> {
+                                TVShowsScreen(
+                                    onTVShowClick = { seriesId ->
+                                        selectedSeriesId = seriesId
+                                        showTVSeasonScreen = true
+                                    },
+                                    modifier = Modifier.padding(innerPadding)
+                                )
+                            }
                         }
                     }
                     AppDestinations.MUSIC -> {

--- a/app/src/main/java/com/example/jellyfinandroid/ui/navigation/AppDestinations.kt
+++ b/app/src/main/java/com/example/jellyfinandroid/ui/navigation/AppDestinations.kt
@@ -22,6 +22,7 @@ enum class AppDestinations(
     LIBRARY("Library", Icons.AutoMirrored.Filled.List),
     MOVIES("Movies", Icons.Default.Movie, false), // Hidden from bottom nav
     TV_SHOWS("TV Shows", Icons.Default.Tv, false), // Hidden from bottom nav
+    TV_EPISODES("Episodes", Icons.Default.Tv, false), // Hidden from bottom nav
     MUSIC("Music", Icons.Default.MusicNote, false), // Hidden from bottom nav
     STUFF("Stuff", Icons.Default.Widgets, false), // Hidden from bottom nav
     SEARCH("Search", Icons.Default.Search),

--- a/app/src/main/java/com/example/jellyfinandroid/ui/screens/TVEpisodesScreen.kt
+++ b/app/src/main/java/com/example/jellyfinandroid/ui/screens/TVEpisodesScreen.kt
@@ -1,0 +1,203 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+package com.example.jellyfinandroid.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import coil.compose.SubcomposeAsyncImage
+import com.example.jellyfinandroid.ui.ShimmerBox
+import com.example.jellyfinandroid.ui.theme.SeriesBlue
+import com.example.jellyfinandroid.ui.viewmodel.SeasonEpisodesViewModel
+import com.example.jellyfinandroid.ui.viewmodel.SeasonEpisodesState
+import org.jellyfin.sdk.model.api.BaseItemDto
+
+@Composable
+fun TVEpisodesScreen(
+    seasonId: String,
+    onBackClick: () -> Unit,
+    getImageUrl: (BaseItemDto) -> String?,
+    modifier: Modifier = Modifier
+) {
+    val viewModel: SeasonEpisodesViewModel = hiltViewModel()
+    val state by viewModel.state.collectAsState()
+
+    LaunchedEffect(seasonId) {
+        viewModel.loadEpisodes(seasonId)
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = "Episodes",
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBackClick) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                },
+                actions = {
+                    IconButton(onClick = { viewModel.refresh() }) {
+                        Icon(
+                            imageVector = Icons.Filled.Refresh,
+                            contentDescription = "Refresh"
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = SeriesBlue.copy(alpha = 0.1f)
+                )
+            )
+        },
+        modifier = modifier
+    ) { innerPadding ->
+        when {
+            state.isLoading -> {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(innerPadding),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator(color = SeriesBlue)
+                }
+            }
+            state.errorMessage != null -> {
+                ErrorContent(
+                    message = state.errorMessage!!,
+                    onRetry = { viewModel.refresh() },
+                    modifier = Modifier.padding(innerPadding)
+                )
+            }
+            else -> {
+                EpisodeList(
+                    episodes = state.episodes,
+                    getImageUrl = getImageUrl,
+                    modifier = Modifier.padding(innerPadding)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun EpisodeList(
+    episodes: List<BaseItemDto>,
+    getImageUrl: (BaseItemDto) -> String?,
+    modifier: Modifier = Modifier
+) {
+    LazyColumn(
+        modifier = modifier,
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        items(episodes) { episode ->
+            EpisodeRow(
+                episode = episode,
+                getImageUrl = getImageUrl
+            )
+        }
+    }
+}
+
+@Composable
+private fun EpisodeRow(
+    episode: BaseItemDto,
+    getImageUrl: (BaseItemDto) -> String?,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface
+        )
+    ) {
+        Row(
+            modifier = Modifier.padding(12.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            SubcomposeAsyncImage(
+                model = getImageUrl(episode),
+                contentDescription = episode.name,
+                loading = {
+                    ShimmerBox(
+                        modifier = Modifier
+                            .width(80.dp)
+                            .height(120.dp),
+                        shape = RoundedCornerShape(8.dp)
+                    )
+                },
+                modifier = Modifier
+                    .width(80.dp)
+                    .height(120.dp)
+                    .clip(RoundedCornerShape(8.dp))
+            )
+
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                Text(
+                    text = episode.name ?: "Episode",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold
+                )
+
+                episode.overview?.let { overview ->
+                    if (overview.isNotBlank()) {
+                        Text(
+                            text = overview,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/jellyfinandroid/ui/screens/TVSeasonScreen.kt
+++ b/app/src/main/java/com/example/jellyfinandroid/ui/screens/TVSeasonScreen.kt
@@ -66,6 +66,7 @@ fun TVSeasonScreen(
     seriesId: String,
     onBackClick: () -> Unit,
     getImageUrl: (BaseItemDto) -> String?,
+    onSeasonClick: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val viewModel: TVSeasonViewModel = hiltViewModel()
@@ -130,6 +131,7 @@ fun TVSeasonScreen(
                 TVSeasonContent(
                     state = state,
                     getImageUrl = getImageUrl,
+                    onSeasonClick = onSeasonClick,
                     modifier = Modifier.padding(innerPadding)
                 )
             }
@@ -141,6 +143,7 @@ fun TVSeasonScreen(
 private fun TVSeasonContent(
     state: TVSeasonState,
     getImageUrl: (BaseItemDto) -> String?,
+    onSeasonClick: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     LazyColumn(
@@ -171,7 +174,8 @@ private fun TVSeasonContent(
             items(state.seasons) { season ->
                 SeasonCard(
                     season = season,
-                    getImageUrl = getImageUrl
+                    getImageUrl = getImageUrl,
+                    onClick = { onSeasonClick(it) }
                 )
             }
         } else {
@@ -335,12 +339,13 @@ private fun SeriesDetailsHeader(
 private fun SeasonCard(
     season: BaseItemDto,
     getImageUrl: (BaseItemDto) -> String?,
+    onClick: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Card(
         modifier = modifier
             .fillMaxWidth()
-            .clickable { /* TODO: Navigate to episodes */ },
+            .clickable { onClick(season.id.toString()) },
         shape = RoundedCornerShape(12.dp),
         elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
         colors = CardDefaults.cardColors(

--- a/app/src/main/java/com/example/jellyfinandroid/ui/viewmodel/SeasonEpisodesViewModel.kt
+++ b/app/src/main/java/com/example/jellyfinandroid/ui/viewmodel/SeasonEpisodesViewModel.kt
@@ -1,0 +1,59 @@
+package com.example.jellyfinandroid.ui.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.jellyfinandroid.data.repository.ApiResult
+import com.example.jellyfinandroid.data.repository.JellyfinRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import org.jellyfin.sdk.model.api.BaseItemDto
+
+data class SeasonEpisodesState(
+    val episodes: List<BaseItemDto> = emptyList(),
+    val isLoading: Boolean = false,
+    val errorMessage: String? = null
+)
+
+@HiltViewModel
+class SeasonEpisodesViewModel @Inject constructor(
+    private val repository: JellyfinRepository
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(SeasonEpisodesState())
+    val state: StateFlow<SeasonEpisodesState> = _state.asStateFlow()
+
+    private var currentSeasonId: String? = null
+
+    fun loadEpisodes(seasonId: String) {
+        viewModelScope.launch {
+            _state.value = _state.value.copy(isLoading = true, errorMessage = null)
+            currentSeasonId = seasonId
+
+            when (val result = repository.getEpisodesForSeason(seasonId)) {
+                is ApiResult.Success -> {
+                    _state.value = _state.value.copy(
+                        episodes = result.data,
+                        isLoading = false
+                    )
+                }
+                is ApiResult.Error -> {
+                    _state.value = _state.value.copy(
+                        isLoading = false,
+                        errorMessage = "Failed to load episodes: ${result.message}"
+                    )
+                }
+                is ApiResult.Loading -> {
+                    // Already handled
+                }
+            }
+        }
+    }
+
+    fun refresh() {
+        currentSeasonId?.let { loadEpisodes(it) }
+    }
+}


### PR DESCRIPTION
## Summary
- allow clicking on seasons to open their episode list
- create a TVEpisodesScreen and SeasonEpisodesViewModel
- add repository method for fetching episodes
- wire up navigation state in MainActivity
- register TV_EPISODES destination

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687044fdbc608327b8b69dffac3de7ea

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a dedicated screen for browsing TV show episodes within a selected season, accessible through the TV Shows navigation flow.
  * Added support for navigating between TV Shows, Seasons, and Episodes with smooth back navigation.
  * Episode lists now display images, titles, and overviews, with loading and error handling.

* **Improvements**
  * Enhanced season selection in the TV Seasons screen, allowing direct access to episode lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->