### PR TITLE
Implement real quick connect API

### DIFF
--- a/app/src/main/java/com/example/jellyfinandroid/ui/viewmodel/ServerConnectionViewModel.kt
+++ b/app/src/main/java/com/example/jellyfinandroid/ui/viewmodel/ServerConnectionViewModel.kt
@@ -353,13 +353,6 @@ class ServerConnectionViewModel @Inject constructor(
                                 }
                             }
                         }
-                        "Denied" -> {
-                            _connectionState.value = _connectionState.value.copy(
-                                isQuickConnectPolling = false,
-                                errorMessage = "Quick Connect was denied by the server"
-                            )
-                            return
-                        }
                         "Expired" -> {
                             _connectionState.value = _connectionState.value.copy(
                                 isQuickConnectPolling = false,


### PR DESCRIPTION
## Summary
- integrate Jellyfin SDK Quick Connect API
- handle polling results and authentication in ServerConnectionViewModel

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687044f56dcc83279fb2c1299724dcc0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quick Connect now uses real-time server authentication, providing accurate connection status updates.
* **Bug Fixes**
  * Improved error handling for Quick Connect, including better classification of expired and authentication errors.
* **Refactor**
  * Removed simulated data and replaced with actual server interactions for Quick Connect.
  * Adjusted polling logic to no longer explicitly handle the "Denied" state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->