### PR TITLE
Fix getUserLibraries API call

### DIFF
--- a/app/src/main/java/com/example/jellyfinandroid/data/repository/JellyfinRepository.kt
+++ b/app/src/main/java/com/example/jellyfinandroid/data/repository/JellyfinRepository.kt
@@ -289,7 +289,7 @@ class JellyfinRepository @Inject constructor(
 
         return try {
             val client = getClient(server.url, server.accessToken)
-            val response = client.itemsApi.getItems(userId = userUuid)
+            val response = client.userApi.getUserViews(userId = userUuid)
             ApiResult.Success(response.content.items ?: emptyList())
         } catch (e: Exception) {
             val errorType = when {


### PR DESCRIPTION
## Summary
- fetch user libraries using `getUserViews` instead of `getItems`

## Testing
- `./gradlew tasks --all`
- `./gradlew testReleaseUnitTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872fdadcf1483279ab98af1587d9dbf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the accuracy of user library data displayed by updating the source of library information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->