### PR TITLE
Use shared QuickConnect models

### DIFF
--- a/app/src/main/java/com/example/jellyfinandroid/data/repository/JellyfinRepository.kt
+++ b/app/src/main/java/com/example/jellyfinandroid/data/repository/JellyfinRepository.kt
@@ -29,16 +29,8 @@ import javax.inject.Singleton
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import com.example.jellyfinandroid.data.SecureCredentialManager
-
-// Quick Connect data classes
-data class QuickConnectResult(
-    val code: String,
-    val secret: String
-)
-
-data class QuickConnectState(
-    val state: String // "Pending", "Approved", "Denied", "Expired"
-)
+import com.example.jellyfinandroid.data.model.QuickConnectResult
+import com.example.jellyfinandroid.data.model.QuickConnectState
 
 sealed class ApiResult<T> {
     data class Success<T>(val data: T) : ApiResult<T>()


### PR DESCRIPTION
## Summary
- remove in-file `QuickConnectResult` and `QuickConnectState`
- import shared models from `QuickConnectModels`

## Testing
- `./gradlew test --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68753619090883279af98c5f8075a32d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code organization by centralizing certain data structures, with no impact on app functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->