### PR TITLE
Use DisposableEffect for resource cleanup

### DIFF
--- a/app/src/main/java/com/example/jellyfinandroid/utils/PerformanceOptimizations.kt
+++ b/app/src/main/java/com/example/jellyfinandroid/utils/PerformanceOptimizations.kt
@@ -3,6 +3,7 @@ package com.example.jellyfinandroid.utils
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -164,12 +165,14 @@ class ResourceManager {
 }
 
 @Composable
+
 fun rememberResourceManager(): ResourceManager {
     val resourceManager = remember { ResourceManager() }
-    
-    LaunchedEffect(Unit) {
-        // Cleanup on disposal
-        resourceManager.cleanup()
+
+    DisposableEffect(Unit) {
+        onDispose {
+            resourceManager.cleanup()
+        }
     }
     
     return resourceManager


### PR DESCRIPTION
## Summary
- use `DisposableEffect` in `rememberResourceManager`

## Testing
- `./gradlew test --no-daemon --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875361bac60832781ccbc29fd1b194c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Optimizations**
  * Improved resource cleanup timing for better app performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->