### PR TITLE
Fix Base64 usage in credential manager

### DIFF
--- a/app/src/main/java/com/example/jellyfinandroid/data/SecureCredentialManager.kt
+++ b/app/src/main/java/com/example/jellyfinandroid/data/SecureCredentialManager.kt
@@ -74,11 +74,7 @@ class SecureCredentialManager @Inject constructor(
 
     private fun decrypt(encryptedData: String): String? {
         return try {
-            val combined = try {
-                Base64.decode(encryptedData, Base64.NO_WRAP)
-            } catch (e: IllegalArgumentException) {
-                Base64.decode(encryptedData, Base64.DEFAULT)
-            }
+            val combined = Base64.decode(encryptedData, Base64.DEFAULT)
             val iv = combined.sliceArray(0..IV_LENGTH - 1)
             val cipherData = combined.sliceArray(IV_LENGTH until combined.size)
             


### PR DESCRIPTION
## Summary
- avoid newline insertion when encoding credentials
- gracefully decode old credentials that might include newlines

## Testing
- `./gradlew testDebugUnitTest` *(fails: SDK location not found)*
- `./gradlew lintDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875361f1c8c8327b825ad17d8bdfdfd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Base64-encoded encrypted data to support both wrapped and unwrapped formats, enhancing compatibility and reliability when decoding credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->