### PR TITLE
Switch QuickConnect to real API

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A modern, beautiful Android client for Jellyfin media servers built with Materia
 - **Server connection testing** before authentication
 - **Token-based authentication** with automatic session management
 - **Multi-server support** (connect to different Jellyfin instances)
-- **Quick Connect** support (coming soon)
+- **Quick Connect** support
 
 ### 📱 **Modern Android Architecture**
 - **Jetpack Compose** for declarative UI

--- a/app/src/main/java/com/example/jellyfinandroid/data/model/QuickConnectModels.kt
+++ b/app/src/main/java/com/example/jellyfinandroid/data/model/QuickConnectModels.kt
@@ -19,16 +19,3 @@ data class QuickConnectState(
     val isExpired: Boolean get() = state == "Expired"
     val isCompleted: Boolean get() = isApproved || isDenied || isExpired
 }
-
-/**
- * ✅ IMPROVEMENT: Constants for QuickConnect configuration
- */
-object QuickConnectConstants {
-    const val CODE_LENGTH = 6
-    const val SECRET_LENGTH = 32
-    const val MAX_POLL_ATTEMPTS = 60 // 5 minutes at 5-second intervals
-    const val POLL_INTERVAL_MS = 5000L
-    
-    // Valid characters for QuickConnect codes
-    const val CODE_CHARACTERS = "0123456789"
-}

--- a/app/src/main/java/com/example/jellyfinandroid/data/repository/JellyfinRepository.kt
+++ b/app/src/main/java/com/example/jellyfinandroid/data/repository/JellyfinRepository.kt
@@ -25,9 +25,7 @@ import org.jellyfin.sdk.model.api.ItemFilter
 import org.jellyfin.sdk.model.api.ImageType
 import org.jellyfin.sdk.model.api.SortOrder
 import org.jellyfin.sdk.model.api.ItemFields
-import com.example.jellyfinandroid.data.model.QuickConnectConstants
 import java.util.UUID
-import java.security.SecureRandom
 import kotlin.random.Random
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -321,13 +319,6 @@ class JellyfinRepository @Inject constructor(
         }
     }
     
-    private fun generateQuickConnectCode(): String {
-        val secureRandom = SecureRandom()
-        val chars = QuickConnectConstants.CODE_CHARACTERS
-        return (1..QuickConnectConstants.CODE_LENGTH)
-            .map { chars[secureRandom.nextInt(chars.length)] }
-            .joinToString("")
-    }
     
     suspend fun getUserLibraries(): ApiResult<List<BaseItemDto>> {
         val server = _currentServer.value


### PR DESCRIPTION
## Summary
- remove the unused QuickConnectConstants
- delete the local `generateQuickConnectCode` helper
- update README to show Quick Connect is fully supported

## Testing
- `./gradlew testDebugUnitTest --quiet` *(fails: SDK location not found)*
- `./gradlew lintDebug --quiet` *(fails: SDK location not found)*
- `./gradlew assembleDebug --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c8f6e42688327bcf3c8033335a660

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README to indicate that the "Quick Connect" feature is now available.
* **Refactor**
  * Removed unused code and constants related to Quick Connect configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->