### PR TITLE
Configure backup rules for Android 12+

### DIFF
--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -5,10 +5,14 @@
 -->
 <data-extraction-rules>
     <cloud-backup>
-        <!-- TODO: Use <include> and <exclude> to control what is backed up.
-        <include .../>
-        <exclude .../>
-        -->
+        <!-- Include user preferences -->
+        <include domain="sharedpref" path="." />
+
+        <!-- Exclude caches and large or sensitive files -->
+        <exclude domain="cache" path="." />
+        <exclude domain="file" path="datastore/secure_credentials.preferences_pb" />
+        <exclude domain="file" path="datastore/offline_downloads.preferences_pb" />
+        <exclude domain="external" path="Movies/JellyfinOffline" />
     </cloud-backup>
     <!--
     <device-transfer>


### PR DESCRIPTION
## Summary
- define cloud-backup include and exclude rules

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c8f6e66708327ae9a58f1f276322a