### PR TITLE
Ensure MainAppViewModel shared across destinations

### DIFF
--- a/app/src/main/java/com/example/jellyfinandroid/ui/JellyfinApp.kt
+++ b/app/src/main/java/com/example/jellyfinandroid/ui/JellyfinApp.kt
@@ -24,7 +24,7 @@ fun JellyfinApp(onLogout: () -> Unit = {}) {
         val connectionState by connectionViewModel.connectionState.collectAsState()
 
         val startDestination = if (connectionState.isConnected) {
-            Screen.Home.route
+            Screen.Main.route
         } else {
             Screen.ServerConnection.route
         }

--- a/app/src/main/java/com/example/jellyfinandroid/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/jellyfinandroid/ui/navigation/NavGraph.kt
@@ -65,9 +65,6 @@ fun JellyfinNavGraph(
     modifier: Modifier = Modifier,
     onLogout: () -> Unit = {}
 ) {
-    val mainEntry = remember(navController) {
-        navController.getBackStackEntry(Screen.ServerConnection.route)
-    }
     NavHost(
         navController = navController,
         startDestination = startDestination,
@@ -117,10 +114,15 @@ fun JellyfinNavGraph(
         }
         
         // Main app flow
-        composable(Screen.Home.route) {
-            val viewModel: MainAppViewModel = hiltViewModel<MainAppViewModel>(mainEntry)
-            val lifecycleOwner = LocalLifecycleOwner.current
-            val appState by viewModel.appState.collectAsStateWithLifecycle()
+        navigation(route = Screen.Main.route, startDestination = Screen.Home.route) {
+            val mainEntry = remember(navController) {
+                navController.getBackStackEntry(Screen.Main.route)
+            }
+
+            composable(Screen.Home.route) {
+                val viewModel: MainAppViewModel = hiltViewModel<MainAppViewModel>(mainEntry)
+                val lifecycleOwner = LocalLifecycleOwner.current
+                val appState by viewModel.appState.collectAsStateWithLifecycle()
             
             HomeScreen(
                 appState = appState,
@@ -166,11 +168,11 @@ fun JellyfinNavGraph(
                 },
                 onSettingsClick = { navController.navigate(Screen.Profile.route) }
             )
-        }
-        
-        composable(Screen.Library.route) {
-            val viewModel = hiltViewModel<MainAppViewModel>(mainEntry)
-            val lifecycleOwner = LocalLifecycleOwner.current
+            }
+
+            composable(Screen.Library.route) {
+                val viewModel = hiltViewModel<MainAppViewModel>(mainEntry)
+                val lifecycleOwner = LocalLifecycleOwner.current
             val appState by viewModel.appState.collectAsStateWithLifecycle(
                 lifecycle = lifecycleOwner.lifecycle,
                 minActiveState = Lifecycle.State.STARTED
@@ -197,11 +199,11 @@ fun JellyfinNavGraph(
                 },
                 onSettingsClick = { navController.navigate(Screen.Profile.route) }
             )
-        }
-        
-        composable(Screen.Movies.route) {
-            val viewModel = hiltViewModel<MainAppViewModel>(mainEntry)
-            val lifecycleOwner = LocalLifecycleOwner.current
+            }
+
+            composable(Screen.Movies.route) {
+                val viewModel = hiltViewModel<MainAppViewModel>(mainEntry)
+                val lifecycleOwner = LocalLifecycleOwner.current
             
             
             MoviesScreen(
@@ -213,11 +215,11 @@ fun JellyfinNavGraph(
                 },
                 viewModel = viewModel
             )
-        }
-        
-        composable(Screen.TVShows.route) {
-            val viewModel = hiltViewModel<MainAppViewModel>(mainEntry)
-            val lifecycleOwner = LocalLifecycleOwner.current
+            }
+
+            composable(Screen.TVShows.route) {
+                val viewModel = hiltViewModel<MainAppViewModel>(mainEntry)
+                val lifecycleOwner = LocalLifecycleOwner.current
             
             
             TVShowsScreen(
@@ -227,9 +229,9 @@ fun JellyfinNavGraph(
                 onBackClick = { navController.popBackStack() },
                 viewModel = viewModel
             )
-        }
-        
-        composable(
+            }
+
+            composable(
             route = Screen.TVSeasons.route,
             arguments = listOf(navArgument(Screen.SERIES_ID_ARG) { type = NavType.StringType })
         ) { backStackEntry ->
@@ -238,8 +240,8 @@ fun JellyfinNavGraph(
                 Log.e("NavGraph", "TVSeasons navigation cancelled: seriesId is null or blank")
                 return@composable
             }
-            val viewModel = hiltViewModel<MainAppViewModel>(mainEntry)
-            val lifecycleOwner = LocalLifecycleOwner.current
+                val viewModel = hiltViewModel<MainAppViewModel>(mainEntry)
+                val lifecycleOwner = LocalLifecycleOwner.current
             
             LaunchedEffect(seriesId) {
                 // Load series data when screen is first shown
@@ -254,9 +256,9 @@ fun JellyfinNavGraph(
                     navController.navigate(Screen.TVEpisodes.createRoute(seasonId))
                 }
             )
-        }
-        
-        composable(
+            }
+
+            composable(
             route = Screen.TVEpisodes.route,
             arguments = listOf(navArgument(Screen.SEASON_ID_ARG) { type = NavType.StringType })
         ) { backStackEntry ->
@@ -266,8 +268,8 @@ fun JellyfinNavGraph(
                 return@composable
             }
             val viewModel = hiltViewModel<SeasonEpisodesViewModel>()
-            val mainViewModel = hiltViewModel<MainAppViewModel>(mainEntry)
-            val lifecycleOwner = LocalLifecycleOwner.current
+                val mainViewModel = hiltViewModel<MainAppViewModel>(mainEntry)
+                val lifecycleOwner = LocalLifecycleOwner.current
             
             LaunchedEffect(seasonId) {
                 // Load episodes when screen is first shown
@@ -289,11 +291,11 @@ fun JellyfinNavGraph(
                 },
                 viewModel = viewModel
             )
-        }
-        
-        composable(Screen.Music.route) {
-            val viewModel = hiltViewModel<MainAppViewModel>(mainEntry)
-            val lifecycleOwner = LocalLifecycleOwner.current
+            }
+
+            composable(Screen.Music.route) {
+                val viewModel = hiltViewModel<MainAppViewModel>(mainEntry)
+                val lifecycleOwner = LocalLifecycleOwner.current
             
             LaunchedEffect(Unit) {
                 // Load music data when screen is first shown
@@ -304,11 +306,11 @@ fun JellyfinNavGraph(
                 onBackClick = { navController.popBackStack() },
                 viewModel = viewModel
             )
-        }
-        
-        composable(Screen.Search.route) {
-            val viewModel = hiltViewModel<MainAppViewModel>(mainEntry)
-            val lifecycleOwner = LocalLifecycleOwner.current
+            }
+
+            composable(Screen.Search.route) {
+                val viewModel = hiltViewModel<MainAppViewModel>(mainEntry)
+                val lifecycleOwner = LocalLifecycleOwner.current
             val appState by viewModel.appState.collectAsStateWithLifecycle(
                 lifecycle = lifecycleOwner.lifecycle,
                 minActiveState = Lifecycle.State.STARTED
@@ -321,11 +323,11 @@ fun JellyfinNavGraph(
                 getImageUrl = { item -> viewModel.getImageUrl(item) },
                 onBackClick = { navController.popBackStack() }
             )
-        }
-        
-        composable(Screen.Favorites.route) {
-            val viewModel = hiltViewModel<MainAppViewModel>(mainEntry)
-            val lifecycleOwner = LocalLifecycleOwner.current
+            }
+
+            composable(Screen.Favorites.route) {
+                val viewModel = hiltViewModel<MainAppViewModel>(mainEntry)
+                val lifecycleOwner = LocalLifecycleOwner.current
             val appState by viewModel.appState.collectAsStateWithLifecycle(
                 lifecycle = lifecycleOwner.lifecycle,
                 minActiveState = Lifecycle.State.STARTED
@@ -343,11 +345,11 @@ fun JellyfinNavGraph(
                 getImageUrl = { item -> viewModel.getImageUrl(item) },
                 onBackClick = { navController.popBackStack() }
             )
-        }
-        
-        composable(Screen.Profile.route) {
-            val viewModel = hiltViewModel<MainAppViewModel>(mainEntry)
-            val lifecycleOwner = LocalLifecycleOwner.current
+            }
+
+            composable(Screen.Profile.route) {
+                val viewModel = hiltViewModel<MainAppViewModel>(mainEntry)
+                val lifecycleOwner = LocalLifecycleOwner.current
             val currentServer by viewModel.currentServer.collectAsStateWithLifecycle(
                 lifecycle = lifecycleOwner.lifecycle,
                 initialValue = null
@@ -358,16 +360,16 @@ fun JellyfinNavGraph(
                 onLogout = {
                     viewModel.logout()
                     onLogout()
-                    navController.popBackStack(Screen.Home.route, inclusive = false)
+                    navController.popBackStack(Screen.Main.route, inclusive = true)
                     navController.navigate(Screen.ServerConnection.route) {
-                        popUpTo(Screen.Home.route) { inclusive = true }
+                        popUpTo(Screen.ServerConnection.route) { inclusive = true }
                     }
                 },
                 onBackClick = { navController.popBackStack() }
             )
         }
-        
-        composable(
+            
+            composable(
             route = Screen.MovieDetail.route,
             arguments = listOf(navArgument(Screen.MOVIE_ID_ARG) { type = NavType.StringType })
         ) { backStackEntry ->
@@ -376,7 +378,7 @@ fun JellyfinNavGraph(
                 Log.e("NavGraph", "MovieDetail navigation cancelled: movieId is null or blank")
                 return@composable
             }
-            val mainViewModel = hiltViewModel<MainAppViewModel>(mainEntry)
+                val mainViewModel = hiltViewModel<MainAppViewModel>(mainEntry)
             val detailViewModel = hiltViewModel<MovieDetailViewModel>()
 
             val lifecycleOwner = LocalLifecycleOwner.current
@@ -433,9 +435,9 @@ fun JellyfinNavGraph(
                     Text(appState.errorMessage ?: "Movie not found")
                 }
             }
-        }
-        
-        composable(
+            }
+
+            composable(
             route = Screen.TVEpisodeDetail.route,
             arguments = listOf(navArgument(Screen.EPISODE_ID_ARG) { type = NavType.StringType })
         ) { backStackEntry ->
@@ -444,7 +446,7 @@ fun JellyfinNavGraph(
                 Log.e("NavGraph", "TVEpisodeDetail navigation cancelled: episodeId is null or blank")
                 return@composable
             }
-            val viewModel = hiltViewModel<MainAppViewModel>(mainEntry)
+                val viewModel = hiltViewModel<MainAppViewModel>(mainEntry)
             val lifecycleOwner = LocalLifecycleOwner.current
             val appState by viewModel.appState.collectAsStateWithLifecycle(
                 lifecycle = lifecycleOwner.lifecycle,
@@ -585,6 +587,7 @@ fun JellyfinNavGraph(
                         CircularProgressIndicator()
                     }
                 }
+            }
             }
         }
     }

--- a/app/src/main/java/com/example/jellyfinandroid/ui/navigation/NavRoutes.kt
+++ b/app/src/main/java/com/example/jellyfinandroid/ui/navigation/NavRoutes.kt
@@ -8,7 +8,10 @@ sealed class Screen(val route: String) {
     // Authentication flow
     object ServerConnection : Screen("server_connection")
     object QuickConnect : Screen("quick_connect")
-    
+
+    // Parent route for main application screens
+    object Main : Screen("main")
+
     // Main app flow
     object Home : Screen("home")
     object Library : Screen("library")


### PR DESCRIPTION
## Summary
- share a parent `NavBackStackEntry` to reuse `MainAppViewModel`
- update all main flow composables to use the shared entry

## Testing
- `./gradlew tasks --all`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687dac54353483278e0cf6d964b52a73

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved navigation flow by introducing a main route grouping primary app screens.
  * Updated app start destination for smoother user experience when connected.
  * Enhanced logout flow to ensure consistent navigation back to server connection screen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->