### PR TITLE
Enable full movie listing

### DIFF
--- a/app/src/main/java/com/example/jellyfinandroid/ui/screens/MoviesScreen.kt
+++ b/app/src/main/java/com/example/jellyfinandroid/ui/screens/MoviesScreen.kt
@@ -117,11 +117,16 @@ fun MoviesScreen(
     var sortOrder by remember { mutableStateOf(MovieSortOrder.getDefault()) }
     var viewMode by remember { mutableStateOf(MovieViewMode.GRID) }
     var showSortMenu by remember { mutableStateOf(false) }
-    
-    // Filter movies from recently added types data (this is where the movies data actually is)
-    val movieItems = remember(appState.recentlyAddedByTypes) {
-        appState.recentlyAddedByTypes["Movies"] ?: emptyList()
+
+    // Load movies when screen is first displayed
+    LaunchedEffect(Unit) {
+        if (appState.allMovies.isEmpty() && !appState.isLoadingMovies) {
+            viewModel.loadAllMovies(reset = true)
+        }
     }
+
+    // Use allMovies list from the view model
+    val movieItems = remember(appState.allMovies) { appState.allMovies }
     
     // Apply filtering and sorting
     val filteredAndSortedMovies = remember(movieItems, selectedFilter, sortOrder) {
@@ -241,7 +246,7 @@ fun MoviesScreen(
                         }
                     }
                     
-                    IconButton(onClick = { viewModel.refreshLibraryItems() }) {
+                    IconButton(onClick = { viewModel.refreshMovies() }) {
                         Icon(
                             imageVector = Icons.Default.Refresh,
                             contentDescription = stringResource(id = R.string.refresh)
@@ -292,7 +297,7 @@ fun MoviesScreen(
             
             // Content
             when {
-                appState.isLoading -> {
+                appState.isLoadingMovies && movieItems.isEmpty() -> {
                     Box(
                         modifier = Modifier.fillMaxSize(),
                         contentAlignment = Alignment.Center
@@ -360,9 +365,9 @@ fun MoviesScreen(
                         viewMode = viewMode,
                         getImageUrl = { item -> viewModel.getImageUrl(item) },
                         onMovieClick = onMovieClick,
-                        isLoadingMore = appState.isLoadingMore,
-                        hasMoreItems = appState.hasMoreItems,
-                        onLoadMore = { viewModel.loadMoreItems() }
+                        isLoadingMore = appState.isLoadingMovies,
+                        hasMoreItems = appState.hasMoreMovies,
+                        onLoadMore = { viewModel.loadMoreMovies() }
                     )
                 }
             }

--- a/app/src/test/java/com/example/jellyfinandroid/ui/viewmodel/MainAppViewModelTest.kt
+++ b/app/src/test/java/com/example/jellyfinandroid/ui/viewmodel/MainAppViewModelTest.kt
@@ -42,7 +42,7 @@ class MainAppViewModelTest {
         coEvery { mockRepository.getUserLibraries() } returns ApiResult.Success(emptyList())
         coEvery { mockRepository.getRecentlyAdded(any()) } returns ApiResult.Success(emptyList())
         coEvery { mockRepository.getRecentlyAddedByTypes(any()) } returns ApiResult.Success(emptyMap())
-        coEvery { mockRepository.getLibraryItems(any(), any()) } returns ApiResult.Success(emptyList())
+        coEvery { mockRepository.getLibraryItems(any(), any(), any(), any()) } returns ApiResult.Success(emptyList())
         
         // Mock StateFlow properties
         every { mockRepository.currentServer } returns MutableStateFlow(null).asStateFlow()


### PR DESCRIPTION
## Summary
- maintain a list of all movies in `MainAppViewModel`
- add `loadAllMovies`, `loadMoreMovies`, and `refreshMovies`
- call movie loading in initial data
- update deletion logic to remove items from movie list
- update Movies screen to use all movies with pagination
- adjust unit test mock for `getLibraryItems`

## Testing
- `./gradlew testDebugUnitTest` *(fails: SDK location not found)*
- `./gradlew lintDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687dac760e108327a63fdc7a76b6f7ee

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added paginated loading for movies, allowing users to load more movies as they scroll.
  * Introduced a refresh option to reload the full movie list.

* **Bug Fixes**
  * Improved loading indicators to more accurately reflect the loading state when movies are being fetched.

* **Chores**
  * Updated internal tests to support new movie loading functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->