### PR TITLE
Simplify Android CI workflow

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -23,5 +23,7 @@ jobs:
     - name: Setup Android SDK
       uses: android-actions/setup-android@v3
     
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
     - name: Build with Gradle
       run: ./gradlew assembleDebug --stacktrace


### PR DESCRIPTION
## Summary
- Simplify Android CI to only checkout, configure Java and Android SDK, and build the debug APK

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68927001c88c8327b45b478d896befd3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified the Android CI workflow to only perform code checkout, environment setup, and project build. Steps related to testing, reporting, and artifact uploads have been removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->