### PR TITLE
refactor: initialize SecureCredentialManagerTest context

### DIFF
--- a/app/src/test/java/com/example/jellyfinandroid/data/SecureCredentialManagerTest.kt
+++ b/app/src/test/java/com/example/jellyfinandroid/data/SecureCredentialManagerTest.kt
@@ -14,11 +14,10 @@ import org.junit.Test
  */
 class SecureCredentialManagerTest {
 
-    private lateinit var mockContext: Context
+    private val mockContext: Context = mockk()
 
     @Before
     fun setup() {
-        mockContext = mockk()
     }
 
     @Test


### PR DESCRIPTION
## Summary
- inline mockContext initialization with mockk
- drop setup-time context assignment

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892937091008327ba227d123202b705

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified the initialization of test mocks for improved test setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->