### PR TITLE
Refactor MainAppViewModelTest mocks

### DIFF
--- a/app/src/test/java/com/example/jellyfinandroid/ui/viewmodel/MainAppViewModelTest.kt
+++ b/app/src/test/java/com/example/jellyfinandroid/ui/viewmodel/MainAppViewModelTest.kt
@@ -26,17 +26,14 @@ import org.junit.Test
 @OptIn(ExperimentalCoroutinesApi::class)
 class MainAppViewModelTest {
 
-    private lateinit var viewModel: MainAppViewModel
-    private lateinit var mockRepository: JellyfinRepository
-    private lateinit var mockCredentialManager: SecureCredentialManager
+    private val mockRepository: JellyfinRepository = mockk(relaxed = true)
+    private val mockCredentialManager: SecureCredentialManager = mockk(relaxed = true)
+    private val viewModel by lazy { MainAppViewModel(mockRepository, mockCredentialManager) }
     private val testDispatcher = StandardTestDispatcher()
 
     @Before
     fun setup() {
         Dispatchers.setMain(testDispatcher)
-
-        mockRepository = mockk(relaxed = true)
-        mockCredentialManager = mockk(relaxed = true)
 
         // Mock repository methods that are called during initialization
         coEvery { mockRepository.getUserLibraries() } returns ApiResult.Success(emptyList())
@@ -47,8 +44,6 @@ class MainAppViewModelTest {
         // Mock StateFlow properties
         every { mockRepository.currentServer } returns MutableStateFlow(null).asStateFlow()
         every { mockRepository.isConnected } returns MutableStateFlow(false).asStateFlow()
-
-        viewModel = MainAppViewModel(mockRepository, mockCredentialManager)
     }
 
     @After


### PR DESCRIPTION
## Summary
- initialize repository and credential manager mocks on declaration
- use lazy ViewModel construction and drop redundant setup assignments

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68929372e1d88327bf569cc16acff788

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the initialization of test components for better reliability and maintainability in the app’s testing suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->