### PR TITLE
Delegate server state to auth repository flows

### DIFF
--- a/app/src/main/java/com/example/jellyfinandroid/data/repository/JellyfinRepository.kt
+++ b/app/src/main/java/com/example/jellyfinandroid/data/repository/JellyfinRepository.kt
@@ -21,7 +21,6 @@ import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.itemsApi
 import org.jellyfin.sdk.api.client.extensions.libraryApi
 import org.jellyfin.sdk.api.client.extensions.playStateApi
-import org.jellyfin.sdk.api.client.extensions.systemApi
 import org.jellyfin.sdk.api.client.extensions.userApi
 import org.jellyfin.sdk.api.client.extensions.userLibraryApi
 import org.jellyfin.sdk.model.api.AuthenticationResult

--- a/app/src/test/java/com/example/jellyfinandroid/data/repository/JellyfinRepositoryTest.kt
+++ b/app/src/test/java/com/example/jellyfinandroid/data/repository/JellyfinRepositoryTest.kt
@@ -4,13 +4,13 @@ import android.content.Context
 import com.example.jellyfinandroid.data.JellyfinServer
 import com.example.jellyfinandroid.data.SecureCredentialManager
 import com.example.jellyfinandroid.di.JellyfinClientFactory
+import io.mockk.every
+import io.mockk.mockk
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
-import io.mockk.mockk
-import io.mockk.every
-import org.junit.Assert.assertEquals
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.*
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 /**

--- a/app/src/test/java/com/example/jellyfinandroid/data/repository/WatchStatusRepositoryTest.kt
+++ b/app/src/test/java/com/example/jellyfinandroid/data/repository/WatchStatusRepositoryTest.kt
@@ -4,8 +4,8 @@ import android.content.Context
 import com.example.jellyfinandroid.data.JellyfinServer
 import com.example.jellyfinandroid.data.SecureCredentialManager
 import com.example.jellyfinandroid.di.JellyfinClientFactory
-import io.mockk.mockk
 import io.mockk.every
+import io.mockk.mockk
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertNotNull


### PR DESCRIPTION
## Summary
- Use authRepository.currentServer and isConnected flows directly in JellyfinRepository
- Remove redundant MutableStateFlow state and update helpers to reference authRepository
- Add unit tests validating repository state mirrors auth repository

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d5be267388327b939fad3324739e2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Centralized authentication and server state management to a single source of truth for improved stability.
  - Streamlined logout and re-authentication flows for more reliable session handling.
  - Consistency improvements across library browsing, search, favorites, seasons/episodes, recently added, and item details.

- Tests
  - Updated test suites to use dependency injection and flow-based authentication state.
  - Added coverage to verify mirrored connection/server state in the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->