### PR TITLE
Refactor home screen sections into modular composables

### DIFF
--- a/app/src/main/java/com/example/jellyfinandroid/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/example/jellyfinandroid/ui/screens/HomeScreen.kt
@@ -339,4 +339,3 @@ fun SearchResultsContent(
         }
     }
 }
-

--- a/app/src/main/java/com/example/jellyfinandroid/ui/screens/home/HomeCarousel.kt
+++ b/app/src/main/java/com/example/jellyfinandroid/ui/screens/home/HomeCarousel.kt
@@ -44,7 +44,7 @@ fun HomeCarousel(
         Text(
             text = title,
             style = MaterialTheme.typography.headlineSmall,
-            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
         )
         val carouselState = rememberCarouselState { movies.size }
         HorizontalUncontainedCarousel(
@@ -54,7 +54,7 @@ fun HomeCarousel(
                 .height(240.dp),
             itemWidth = 280.dp,
             itemSpacing = 12.dp,
-            contentPadding = PaddingValues(horizontal = 16.dp)
+            contentPadding = PaddingValues(horizontal = 16.dp),
         ) { index ->
             val movie = movies[index]
             CarouselMovieCard(
@@ -63,7 +63,7 @@ fun HomeCarousel(
                 onClick = onItemClick,
                 modifier = Modifier
                     .fillMaxSize()
-                    .clip(RoundedCornerShape(16.dp))
+                    .clip(RoundedCornerShape(16.dp)),
             )
         }
     }
@@ -81,8 +81,8 @@ private fun CarouselMovieCard(
         shape = RoundedCornerShape(16.dp),
         elevation = CardDefaults.cardElevation(defaultElevation = 8.dp),
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surface
-        )
+            containerColor = MaterialTheme.colorScheme.surface,
+        ),
     ) {
         Box(modifier = Modifier.fillMaxSize()) {
             AsyncImage(
@@ -94,7 +94,7 @@ private fun CarouselMovieCard(
                 modifier = Modifier
                     .fillMaxSize()
                     .clip(RoundedCornerShape(16.dp)),
-                contentScale = ContentScale.Crop
+                contentScale = ContentScale.Crop,
             )
             movie.communityRating?.let { rating ->
                 Surface(
@@ -103,13 +103,13 @@ private fun CarouselMovieCard(
                         .padding(12.dp),
                     shape = RoundedCornerShape(8.dp),
                     color = MaterialTheme.colorScheme.primary.copy(alpha = 0.95f),
-                    shadowElevation = 4.dp
+                    shadowElevation = 4.dp,
                 ) {
                     Text(
                         text = "★ ${String.format(java.util.Locale.ROOT, "%.1f", rating)}",
                         style = MaterialTheme.typography.labelMedium,
                         color = Color.White,
-                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)
+                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
                     )
                 }
             }
@@ -117,13 +117,13 @@ private fun CarouselMovieCard(
                 verticalArrangement = Arrangement.spacedBy(8.dp),
                 modifier = Modifier
                     .align(Alignment.BottomStart)
-                    .padding(16.dp)
+                    .padding(16.dp),
             ) {
                 Text(
                     text = movie.name ?: "Unknown Movie",
                     style = MaterialTheme.typography.titleLarge,
                     color = Color.White,
-                    maxLines = 2
+                    maxLines = 2,
                 )
             }
         }
@@ -137,7 +137,6 @@ private fun HomeCarouselPreview() {
         movies = listOf(BaseItemDto(name = "Movie 1"), BaseItemDto(name = "Movie 2")),
         getBackdropUrl = { null },
         onItemClick = {},
-        title = "Recently Added Movies"
+        title = "Recently Added Movies",
     )
 }
-

--- a/app/src/main/java/com/example/jellyfinandroid/ui/screens/home/LibraryGridSection.kt
+++ b/app/src/main/java/com/example/jellyfinandroid/ui/screens/home/LibraryGridSection.kt
@@ -8,8 +8,8 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -47,23 +47,24 @@ fun LibraryGridSection(
             text = title,
             style = MaterialTheme.typography.headlineSmall,
             fontWeight = FontWeight.Bold,
-            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
         )
         LazyRow(
             contentPadding = PaddingValues(horizontal = 16.dp),
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier.fillMaxWidth(),
         ) {
             items(libraries, key = { it.id ?: it.name ?: "" }) { library ->
                 LibraryCard(
                     library = library,
                     getImageUrl = getImageUrl,
                     onClick = onLibraryClick,
-                    modifier = Modifier.padding(end = 12.dp)
+                    modifier = Modifier.padding(end = 12.dp),
                 )
             }
         }
     }
 }
+
 @Composable
 private fun LibraryCard(
     library: BaseItemDto,
@@ -76,7 +77,7 @@ private fun LibraryCard(
         modifier = modifier.width(200.dp).clickable { onClick(library) },
         shape = RoundedCornerShape(12.dp),
         elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
     ) {
         Column {
             Box {
@@ -86,7 +87,7 @@ private fun LibraryCard(
                     loading = {
                         ShimmerBox(
                             modifier = Modifier.fillMaxWidth().height(120.dp),
-                            cornerRadius = 12
+                            cornerRadius = 12,
                         )
                     },
                     error = {
@@ -94,19 +95,19 @@ private fun LibraryCard(
                             modifier = Modifier.fillMaxWidth().height(120.dp)
                                 .background(contentTypeColor.copy(alpha = 0.1f))
                                 .clip(RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp)),
-                            contentAlignment = Alignment.Center
+                            contentAlignment = Alignment.Center,
                         ) {
                             Icon(
                                 imageVector = Icons.Default.Folder,
                                 contentDescription = "Library",
                                 modifier = Modifier.size(48.dp),
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
                         }
                     },
                     contentScale = ContentScale.Crop,
                     modifier = Modifier.fillMaxWidth().height(120.dp)
-                        .clip(RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp))
+                        .clip(RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp)),
                 )
             }
             Column(modifier = Modifier.padding(12.dp)) {
@@ -116,7 +117,7 @@ private fun LibraryCard(
                     fontWeight = FontWeight.SemiBold,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
-                    color = MaterialTheme.colorScheme.onSurface
+                    color = MaterialTheme.colorScheme.onSurface,
                 )
                 library.type?.let { type ->
                     Text(
@@ -124,13 +125,14 @@ private fun LibraryCard(
                             .replaceFirstChar { it.uppercase() },
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.padding(top = 4.dp)
+                        modifier = Modifier.padding(top = 4.dp),
                     )
                 }
             }
         }
     }
 }
+
 @Preview(showBackground = true)
 @Composable
 private fun LibraryGridSectionPreview() {
@@ -138,6 +140,6 @@ private fun LibraryGridSectionPreview() {
         libraries = listOf(BaseItemDto(name = "Library")),
         getImageUrl = { null },
         onLibraryClick = {},
-        title = "Libraries"
+        title = "Libraries",
     )
 }

--- a/app/src/main/java/com/example/jellyfinandroid/ui/screens/home/RecentlyAddedSection.kt
+++ b/app/src/main/java/com/example/jellyfinandroid/ui/screens/home/RecentlyAddedSection.kt
@@ -15,8 +15,8 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.jellyfinandroid.ui.components.RecentlyAddedCard
@@ -38,7 +38,7 @@ fun RecentlyAddedSection(
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp, vertical = 8.dp),
             horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
+            verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(text = title, style = MaterialTheme.typography.headlineSmall)
             IconButton(onClick = onRefresh) {
@@ -47,7 +47,7 @@ fun RecentlyAddedSection(
         }
         LazyRow(
             contentPadding = PaddingValues(horizontal = 16.dp),
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier.fillMaxWidth(),
         ) {
             items(items, key = { it.id ?: it.name ?: "" }) { item ->
                 RecentlyAddedCard(
@@ -55,12 +55,13 @@ fun RecentlyAddedSection(
                     getImageUrl = getImageUrl,
                     getSeriesImageUrl = getSeriesImageUrl,
                     onClick = onItemClick,
-                    modifier = Modifier.padding(end = 12.dp)
+                    modifier = Modifier.padding(end = 12.dp),
                 )
             }
         }
     }
 }
+
 @Preview(showBackground = true)
 @Composable
 private fun RecentlyAddedSectionPreview() {
@@ -70,6 +71,6 @@ private fun RecentlyAddedSectionPreview() {
         getImageUrl = { null },
         getSeriesImageUrl = { null },
         onItemClick = {},
-        onRefresh = {}
+        onRefresh = {},
     )
 }


### PR DESCRIPTION
## Summary
- break out HomeCarousel, LibraryGridSection, and RecentlyAddedSection into separate files with previews
- simplify HomeScreen to orchestrate new components

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fbb2aab2c8327ba6b35044a159e68

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Titled movie carousel on Home with click-through and rating badges.
  * Library grid section with images and type labels.
  * Recently Added section with a refresh action.

* **Refactor**
  * Home screen rebuilt with reusable sections for a more consistent look and titles.
  * Smoother image loading with placeholders and error fallbacks.
  * Polished horizontal layouts and spacing; clearer grouping titles in search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->