### PR TITLE
feat: add media and user repositories

### DIFF
--- a/app/src/main/java/com/example/jellyfinandroid/data/repository/JellyfinMediaRepository.kt
+++ b/app/src/main/java/com/example/jellyfinandroid/data/repository/JellyfinMediaRepository.kt
@@ -1,0 +1,138 @@
+package com.example.jellyfinandroid.data.repository
+
+import com.example.jellyfinandroid.data.repository.common.BaseJellyfinRepository
+import org.jellyfin.sdk.model.api.BaseItemDto
+import org.jellyfin.sdk.model.api.BaseItemKind
+import org.jellyfin.sdk.model.api.ItemSortBy
+import org.jellyfin.sdk.model.api.SortOrder
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Repository containing media-related operations that were previously
+ * part of the large [JellyfinRepository]. The implementations here are
+ * intentionally lightweight and focused on simple request execution.
+ */
+@Singleton
+class JellyfinMediaRepository @Inject constructor(
+    authRepository: JellyfinAuthRepository,
+    clientFactory: com.example.jellyfinandroid.di.JellyfinClientFactory,
+) : BaseJellyfinRepository(authRepository, clientFactory) {
+
+    suspend fun getUserLibraries(): ApiResult<List<BaseItemDto>> = execute {
+        val server = validateServer()
+        val userUuid = parseUuid(server.userId ?: "", "user")
+        val client = getClient(server.url, server.accessToken)
+        val response = client.itemsApi.getItems(
+            userId = userUuid,
+            includeItemTypes = listOf(BaseItemKind.COLLECTION_FOLDER),
+        )
+        response.content.items ?: emptyList()
+    }
+
+    suspend fun getLibraryItems(
+        parentId: String? = null,
+        itemTypes: String? = null,
+        startIndex: Int = 0,
+        limit: Int = 100,
+    ): ApiResult<List<BaseItemDto>> = execute {
+        val server = validateServer()
+        val userUuid = parseUuid(server.userId ?: "", "user")
+        val client = getClient(server.url, server.accessToken)
+        val parent = parentId?.let { parseUuid(it, "parent") }
+        val itemKinds = itemTypes?.split(",")?.mapNotNull { type ->
+            when (type.trim()) {
+                "Movie" -> BaseItemKind.MOVIE
+                "Series" -> BaseItemKind.SERIES
+                "Episode" -> BaseItemKind.EPISODE
+                "Audio" -> BaseItemKind.AUDIO
+                else -> null
+            }
+        }
+        val response = client.itemsApi.getItems(
+            userId = userUuid,
+            parentId = parent,
+            recursive = true,
+            includeItemTypes = itemKinds,
+            startIndex = startIndex,
+            limit = limit,
+        )
+        response.content.items ?: emptyList()
+    }
+
+    suspend fun getRecentlyAdded(limit: Int = 20): ApiResult<List<BaseItemDto>> = execute {
+        val server = validateServer()
+        val userUuid = parseUuid(server.userId ?: "", "user")
+        val client = getClient(server.url, server.accessToken)
+        val response = client.itemsApi.getItems(
+            userId = userUuid,
+            recursive = true,
+            includeItemTypes = listOf(
+                BaseItemKind.MOVIE,
+                BaseItemKind.SERIES,
+                BaseItemKind.EPISODE,
+                BaseItemKind.AUDIO,
+                BaseItemKind.MUSIC_ALBUM,
+                BaseItemKind.MUSIC_ARTIST,
+                BaseItemKind.BOOK,
+                BaseItemKind.AUDIO_BOOK,
+                BaseItemKind.VIDEO,
+            ),
+            sortBy = listOf(ItemSortBy.DATE_CREATED),
+            sortOrder = listOf(SortOrder.DESCENDING),
+            limit = limit,
+        )
+        response.content.items ?: emptyList()
+    }
+
+    suspend fun getRecentlyAddedByType(
+        itemType: BaseItemKind,
+        limit: Int = 20,
+    ): ApiResult<List<BaseItemDto>> = execute {
+        val server = validateServer()
+        val userUuid = parseUuid(server.userId ?: "", "user")
+        val client = getClient(server.url, server.accessToken)
+        val response = client.itemsApi.getItems(
+            userId = userUuid,
+            recursive = true,
+            includeItemTypes = listOf(itemType),
+            sortBy = listOf(ItemSortBy.DATE_CREATED),
+            sortOrder = listOf(SortOrder.DESCENDING),
+            limit = limit,
+        )
+        response.content.items ?: emptyList()
+    }
+
+    suspend fun getRecentlyAddedByTypes(limit: Int = 20): ApiResult<Map<String, List<BaseItemDto>>> = execute {
+        val types = listOf(
+            BaseItemKind.MOVIE,
+            BaseItemKind.SERIES,
+            BaseItemKind.EPISODE,
+        )
+        val result = mutableMapOf<String, List<BaseItemDto>>()
+        for (type in types) {
+            when (val res = getRecentlyAddedByType(type, limit)) {
+                is ApiResult.Success -> if (res.data.isNotEmpty()) {
+                    result[type.name] = res.data
+                }
+                else -> {}
+            }
+        }
+        result
+    }
+
+    suspend fun getSeasonsForSeries(seriesId: String): ApiResult<List<BaseItemDto>> = execute {
+        val server = validateServer()
+        val userUuid = parseUuid(server.userId ?: "", "user")
+        val seriesUuid = parseUuid(seriesId, "series")
+        val client = getClient(server.url, server.accessToken)
+        val response = client.itemsApi.getItems(
+            userId = userUuid,
+            parentId = seriesUuid,
+            includeItemTypes = listOf(BaseItemKind.SEASON),
+            sortBy = listOf(ItemSortBy.SORT_NAME),
+            sortOrder = listOf(SortOrder.ASCENDING),
+        )
+        response.content.items ?: emptyList()
+    }
+}

--- a/app/src/main/java/com/example/jellyfinandroid/data/repository/JellyfinRepositoryCoordinator.kt
+++ b/app/src/main/java/com/example/jellyfinandroid/data/repository/JellyfinRepositoryCoordinator.kt
@@ -1,0 +1,17 @@
+package com.example.jellyfinandroid.data.repository
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Simple coordinator that exposes the different repository components.
+ * This allows consumers to receive a single dependency when multiple
+ * repositories are required together.
+ */
+@Singleton
+class JellyfinRepositoryCoordinator @Inject constructor(
+    val media: JellyfinMediaRepository,
+    val user: JellyfinUserRepository,
+    val stream: JellyfinStreamRepository,
+    val auth: JellyfinAuthRepository,
+)

--- a/app/src/main/java/com/example/jellyfinandroid/data/repository/JellyfinUserRepository.kt
+++ b/app/src/main/java/com/example/jellyfinandroid/data/repository/JellyfinUserRepository.kt
@@ -1,0 +1,59 @@
+package com.example.jellyfinandroid.data.repository
+
+import com.example.jellyfinandroid.data.repository.common.BaseJellyfinRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Repository that contains operations specific to the user or session.
+ * Functions here were previously scattered across [JellyfinRepository].
+ */
+@Singleton
+class JellyfinUserRepository @Inject constructor(
+    authRepository: JellyfinAuthRepository,
+    clientFactory: com.example.jellyfinandroid.di.JellyfinClientFactory,
+) : BaseJellyfinRepository(authRepository, clientFactory) {
+
+    suspend fun logout() {
+        authRepository.logout()
+    }
+
+    suspend fun toggleFavorite(itemId: String, isFavorite: Boolean): ApiResult<Boolean> = execute {
+        val server = validateServer()
+        val userUuid = parseUuid(server.userId ?: "", "user")
+        val itemUuid = parseUuid(itemId, "item")
+        val client = getClient(server.url, server.accessToken)
+        if (isFavorite) {
+            client.userLibraryApi.unmarkFavoriteItem(itemId = itemUuid, userId = userUuid)
+        } else {
+            client.userLibraryApi.markFavoriteItem(itemId = itemUuid, userId = userUuid)
+        }
+        !isFavorite
+    }
+
+    suspend fun markAsWatched(itemId: String): ApiResult<Boolean> = execute {
+        val server = validateServer()
+        val userUuid = parseUuid(server.userId ?: "", "user")
+        val itemUuid = parseUuid(itemId, "item")
+        val client = getClient(server.url, server.accessToken)
+        client.playStateApi.markPlayedItem(itemId = itemUuid, userId = userUuid)
+        true
+    }
+
+    suspend fun markAsUnwatched(itemId: String): ApiResult<Boolean> = execute {
+        val server = validateServer()
+        val userUuid = parseUuid(server.userId ?: "", "user")
+        val itemUuid = parseUuid(itemId, "item")
+        val client = getClient(server.url, server.accessToken)
+        client.playStateApi.markUnplayedItem(itemId = itemUuid, userId = userUuid)
+        true
+    }
+
+    suspend fun deleteItemAsAdmin(itemId: String): ApiResult<Boolean> = execute {
+        val server = validateServer()
+        val itemUuid = parseUuid(itemId, "item")
+        val client = getClient(server.url, server.accessToken)
+        client.libraryApi.deleteItem(itemId = itemUuid)
+        true
+    }
+}

--- a/app/src/main/java/com/example/jellyfinandroid/data/repository/common/ApiResult.kt
+++ b/app/src/main/java/com/example/jellyfinandroid/data/repository/common/ApiResult.kt
@@ -1,0 +1,30 @@
+package com.example.jellyfinandroid.data.repository
+
+/**
+ * Represents a simple result wrapper for repository operations.
+ * Moved to common package so multiple repositories can share the same type.
+ */
+sealed class ApiResult<out T> {
+    data class Success<T>(val data: T) : ApiResult<T>()
+    data class Error<T>(
+        val message: String,
+        val cause: Throwable? = null,
+        val errorType: ErrorType = ErrorType.UNKNOWN
+    ) : ApiResult<T>()
+    class Loading<T>(val message: String = "") : ApiResult<T>()
+}
+
+/**
+ * Basic error categories that repository calls may surface.
+ * Kept minimal for test friendliness.
+ */
+enum class ErrorType {
+    NETWORK,
+    AUTHENTICATION,
+    SERVER_ERROR,
+    NOT_FOUND,
+    UNAUTHORIZED,
+    FORBIDDEN,
+    OPERATION_CANCELLED,
+    UNKNOWN,
+}

--- a/app/src/main/java/com/example/jellyfinandroid/data/repository/common/BaseJellyfinRepository.kt
+++ b/app/src/main/java/com/example/jellyfinandroid/data/repository/common/BaseJellyfinRepository.kt
@@ -1,0 +1,42 @@
+package com.example.jellyfinandroid.data.repository.common
+
+import com.example.jellyfinandroid.data.JellyfinServer
+import com.example.jellyfinandroid.data.repository.ApiResult
+import com.example.jellyfinandroid.data.repository.ErrorType
+import com.example.jellyfinandroid.data.repository.JellyfinAuthRepository
+import com.example.jellyfinandroid.data.utils.RepositoryUtils
+import com.example.jellyfinandroid.di.JellyfinClientFactory
+import org.jellyfin.sdk.api.client.ApiClient
+import javax.inject.Inject
+
+/**
+ * Lightweight base class shared by repository implementations.
+ * It centralizes common helpers like client creation and safe
+ * execution wrappers so individual repositories can stay focused
+ * on their domain logic.
+ */
+open class BaseJellyfinRepository @Inject constructor(
+    protected val authRepository: JellyfinAuthRepository,
+    private val clientFactory: JellyfinClientFactory,
+) {
+    protected fun getClient(serverUrl: String, accessToken: String?): ApiClient =
+        clientFactory.getClient(serverUrl, accessToken)
+
+    protected fun validateServer(): JellyfinServer =
+        RepositoryUtils.validateServer(authRepository.getCurrentServer())
+
+    protected fun parseUuid(id: String, type: String) =
+        RepositoryUtils.parseUuid(id, type)
+
+    /**
+     * Wraps a suspend block returning [ApiResult]. Any thrown exception
+     * is converted to an [ApiResult.Error] with a best-effort error type.
+     */
+    protected suspend fun <T> execute(block: suspend () -> T): ApiResult<T> =
+        try {
+            ApiResult.Success(block())
+        } catch (e: Exception) {
+            val error = RepositoryUtils.getErrorType(e)
+            ApiResult.Error(e.message ?: "Unknown error", e, error)
+        }
+}

--- a/app/src/main/java/com/example/jellyfinandroid/ui/viewmodel/TVSeasonViewModel.kt
+++ b/app/src/main/java/com/example/jellyfinandroid/ui/viewmodel/TVSeasonViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.jellyfinandroid.data.repository.ApiResult
 import com.example.jellyfinandroid.data.repository.JellyfinRepository
+import com.example.jellyfinandroid.data.repository.JellyfinMediaRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -22,6 +23,7 @@ data class TVSeasonState(
 @HiltViewModel
 class TVSeasonViewModel @Inject constructor(
     private val repository: JellyfinRepository,
+    private val mediaRepository: JellyfinMediaRepository,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(TVSeasonState())
@@ -47,7 +49,7 @@ class TVSeasonViewModel @Inject constructor(
             }
 
             // Load seasons
-            when (val seasonsResult = repository.getSeasonsForSeries(seriesId)) {
+            when (val seasonsResult = mediaRepository.getSeasonsForSeries(seriesId)) {
                 is ApiResult.Success -> {
                     _state.value = _state.value.copy(
                         seasons = seasonsResult.data,

--- a/app/src/test/java/com/example/jellyfinandroid/data/repository/WatchStatusRepositoryTest.kt
+++ b/app/src/test/java/com/example/jellyfinandroid/data/repository/WatchStatusRepositoryTest.kt
@@ -18,7 +18,7 @@ class WatchStatusRepositoryTest {
     private val credentialManager = mockk<SecureCredentialManager>(relaxed = true)
     private val context = mockk<Context>(relaxed = true)
 
-    private fun createRepositoryWithServer(): JellyfinRepository {
+    private fun createRepositoryWithServer(): JellyfinUserRepository {
         val server = JellyfinServer(
             id = "a4b6-4a3e-8b0a-0a8b0a0a8b0a",
             name = "Test",
@@ -32,8 +32,7 @@ class WatchStatusRepositoryTest {
             every { currentServer } returns MutableStateFlow(server)
             every { isConnected } returns MutableStateFlow(true)
         }
-        val streamRepository = mockk<JellyfinStreamRepository>(relaxed = true)
-        return JellyfinRepository(clientFactory, credentialManager, context, authRepository, streamRepository)
+        return JellyfinUserRepository(authRepository, clientFactory)
     }
 
     @Test
@@ -44,8 +43,7 @@ class WatchStatusRepositoryTest {
             every { getCurrentServer() } returns null
             every { isUserAuthenticated() } returns false
         }
-        val streamRepository = mockk<JellyfinStreamRepository>(relaxed = true)
-        val repository = JellyfinRepository(clientFactory, credentialManager, context, authRepository, streamRepository)
+        val repository = JellyfinUserRepository(authRepository, clientFactory)
         assertNotNull(repository)
     }
 


### PR DESCRIPTION
## Summary
- add ApiResult and BaseJellyfinRepository base utilities
- introduce JellyfinMediaRepository and JellyfinUserRepository with core operations
- wire view models to new repositories and add repository coordinator
- update watch status tests for new user repository

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fbb295604832793469f9bd2018135

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced library browsing with pagination and “Recently Added” by type.
  * Improved season listings for TV series.
  * Streamlined user actions: toggle favorites, mark watched/unwatched, logout.
  * More reliable images and playback links.

* **Improvements**
  * Smoother initial loading with reduced duplicate fetches.
  * Clearer error handling; canceled operations no longer show error toasts.

* **Refactor**
  * Modularized data layer into dedicated media, user, and streaming components.
  * Unified result handling for more consistent behavior and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->