### PR TITLE
Log network exceptions in base repository

### DIFF
--- a/app/src/main/java/com/example/jellyfinandroid/data/repository/common/BaseJellyfinRepository.kt
+++ b/app/src/main/java/com/example/jellyfinandroid/data/repository/common/BaseJellyfinRepository.kt
@@ -1,13 +1,13 @@
 package com.example.jellyfinandroid.data.repository.common
 
+import com.example.jellyfinandroid.core.LogCategory
+import com.example.jellyfinandroid.core.Logger
 import com.example.jellyfinandroid.data.JellyfinServer
 import com.example.jellyfinandroid.data.cache.JellyfinCache
 import com.example.jellyfinandroid.data.repository.JellyfinAuthRepository
 import com.example.jellyfinandroid.data.utils.RepositoryUtils
 import com.example.jellyfinandroid.di.JellyfinClientFactory
 import com.example.jellyfinandroid.ui.utils.RetryManager
-import com.example.jellyfinandroid.core.LogCategory
-import com.example.jellyfinandroid.core.Logger
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.model.api.BaseItemDto
 import javax.inject.Inject


### PR DESCRIPTION
## Summary
- log network operation failures inside `execute`, `executeWithRetry`, and `executeWithRetryAndCircuitBreaker`
- include operation name and use unified Logger with `LogCategory.NETWORK`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a54dbadf4c8327874439eded46a6b4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal error logging for repository operations, including detailed per-attempt logs during retries and circuit breaker flows, to aid diagnostics. No change to normal behavior or user-facing features.
* **Refactor**
  * Standardized internal execution API to include operation names for clearer logging and traceability. No functional or UI impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->