### PR TITLE
Add view model and navigation tests with CI task

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -133,6 +133,7 @@ dependencies {
     testImplementation(libs.androidx.arch.core.testing)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
+    androidTestImplementation(libs.androidx.navigation.testing)
     androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.androidx.ui.test.junit4)
     debugImplementation(libs.androidx.ui.tooling)

--- a/app/src/androidTest/java/com/example/jellyfinandroid/ui/navigation/NavigationFlowTest.kt
+++ b/app/src/androidTest/java/com/example/jellyfinandroid/ui/navigation/NavigationFlowTest.kt
@@ -1,0 +1,57 @@
+package com.example.jellyfinandroid.ui.navigation
+
+import androidx.activity.ComponentActivity
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.navigation.compose.ComposeNavigator
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.testing.TestNavHostController
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+class NavigationFlowTest {
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun navigateFromSeasonsToEpisodes() {
+        lateinit var navController: TestNavHostController
+
+        composeRule.setContent {
+            navController = rememberTestNavController()
+            TestNavGraph(navController)
+        }
+
+        composeRule.onNodeWithText("Load Episodes").performClick()
+        assertEquals("episodes", navController.currentDestination?.route)
+        composeRule.onNodeWithText("Episodes Screen").assertExists()
+    }
+}
+
+@Composable
+fun rememberTestNavController(): TestNavHostController {
+    val context = LocalContext.current
+    val navController = TestNavHostController(context)
+    navController.navigatorProvider.addNavigator(ComposeNavigator())
+    return navController
+}
+
+@Composable
+fun TestNavGraph(navController: TestNavHostController) {
+    NavHost(navController, startDestination = "seasons") {
+        composable("seasons") {
+            Button(onClick = { navController.navigate("episodes") }) {
+                Text("Load Episodes")
+            }
+        }
+        composable("episodes") {
+            Text("Episodes Screen")
+        }
+    }
+}

--- a/app/src/test/java/com/example/jellyfinandroid/ui/downloads/DownloadsViewModelTest.kt
+++ b/app/src/test/java/com/example/jellyfinandroid/ui/downloads/DownloadsViewModelTest.kt
@@ -1,0 +1,96 @@
+package com.example.jellyfinandroid.ui.downloads
+
+import android.content.Context
+import com.example.jellyfinandroid.data.offline.DownloadStatus
+import com.example.jellyfinandroid.data.offline.OfflineDownload
+import com.example.jellyfinandroid.data.offline.OfflineDownloadManager
+import com.example.jellyfinandroid.data.offline.OfflinePlaybackManager
+import io.mockk.MockKAnnotations
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DownloadsViewModelTest {
+
+    @MockK(relaxUnitFun = true)
+    lateinit var downloadManager: OfflineDownloadManager
+
+    @MockK(relaxUnitFun = true)
+    lateinit var playbackManager: OfflinePlaybackManager
+
+    @MockK
+    lateinit var context: Context
+
+    private lateinit var viewModel: DownloadsViewModel
+    private val dispatcher = UnconfinedTestDispatcher()
+
+    private lateinit var downloadsFlow: MutableStateFlow<List<OfflineDownload>>
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this)
+        Dispatchers.setMain(dispatcher)
+        downloadsFlow = MutableStateFlow(emptyList())
+        every { downloadManager.downloads } returns downloadsFlow
+        every { downloadManager.downloadProgress } returns MutableStateFlow(emptyMap())
+        viewModel = DownloadsViewModel(context, downloadManager, playbackManager)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `pauseAllDownloads pauses active downloads`() = runTest {
+        val downloading = OfflineDownload(
+            id = "1",
+            jellyfinItemId = "j1",
+            itemName = "Item1",
+            itemType = "episode",
+            downloadUrl = "",
+            localFilePath = "",
+            fileSize = 0L,
+            status = DownloadStatus.DOWNLOADING,
+        )
+        val completed = downloading.copy(id = "2", status = DownloadStatus.COMPLETED)
+        downloadsFlow.value = listOf(downloading, completed)
+
+        viewModel.pauseAllDownloads()
+
+        coVerify { downloadManager.pauseDownload("1") }
+        coVerify(exactly = 0) { downloadManager.pauseDownload("2") }
+    }
+
+    @Test
+    fun `clearCompletedDownloads deletes completed downloads`() = runTest {
+        val downloading = OfflineDownload(
+            id = "1",
+            jellyfinItemId = "j1",
+            itemName = "Item1",
+            itemType = "episode",
+            downloadUrl = "",
+            localFilePath = "",
+            fileSize = 0L,
+            status = DownloadStatus.DOWNLOADING,
+        )
+        val completed = downloading.copy(id = "2", status = DownloadStatus.COMPLETED)
+        downloadsFlow.value = listOf(downloading, completed)
+
+        viewModel.clearCompletedDownloads()
+
+        coVerify { downloadManager.deleteDownload("2") }
+        coVerify(exactly = 0) { downloadManager.deleteDownload("1") }
+    }
+}

--- a/app/src/test/java/com/example/jellyfinandroid/ui/viewmodel/SeasonEpisodesViewModelTest.kt
+++ b/app/src/test/java/com/example/jellyfinandroid/ui/viewmodel/SeasonEpisodesViewModelTest.kt
@@ -1,0 +1,94 @@
+package com.example.jellyfinandroid.ui.viewmodel
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.example.jellyfinandroid.data.repository.JellyfinRepository
+import com.example.jellyfinandroid.data.repository.common.ApiResult
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.jellyfin.sdk.model.api.BaseItemDto
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SeasonEpisodesViewModelTest {
+
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    @MockK
+    private lateinit var repository: JellyfinRepository
+
+    private lateinit var viewModel: SeasonEpisodesViewModel
+    private val dispatcher = UnconfinedTestDispatcher()
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this)
+        Dispatchers.setMain(dispatcher)
+        viewModel = SeasonEpisodesViewModel(repository)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `initial state is correct`() = runTest {
+        val state = viewModel.state.first()
+        assertTrue(state.episodes.isEmpty())
+        assertFalse(state.isLoading)
+        assertNull(state.errorMessage)
+    }
+
+    @Test
+    fun `loadEpisodes updates state on success`() = runTest {
+        val seasonId = "season1"
+        val episodes = listOf(mockk<BaseItemDto>())
+        coEvery { repository.getEpisodesForSeason(seasonId) } returns ApiResult.Success(episodes)
+
+        viewModel.loadEpisodes(seasonId)
+
+        val state = viewModel.state.first()
+        assertEquals(episodes, state.episodes)
+        assertFalse(state.isLoading)
+        assertNull(state.errorMessage)
+    }
+
+    @Test
+    fun `loadEpisodes handles error`() = runTest {
+        val seasonId = "season1"
+        coEvery { repository.getEpisodesForSeason(seasonId) } returns ApiResult.Error("error")
+
+        viewModel.loadEpisodes(seasonId)
+
+        val state = viewModel.state.first()
+        assertTrue(state.episodes.isEmpty())
+        assertFalse(state.isLoading)
+        assertEquals("Failed to load episodes: error", state.errorMessage)
+    }
+
+    @Test
+    fun `refresh reloads current season`() = runTest {
+        val seasonId = "season1"
+        coEvery { repository.getEpisodesForSeason(seasonId) } returns ApiResult.Success(emptyList())
+
+        viewModel.loadEpisodes(seasonId)
+        viewModel.refresh()
+
+        coVerify(exactly = 2) { repository.getEpisodesForSeason(seasonId) }
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,3 +7,7 @@ plugins {
     alias(libs.plugins.dagger.hilt.android) apply false
     alias(libs.plugins.ksp) apply false
 }
+
+tasks.register("ciTest") {
+    dependsOn(":app:testDebugUnitTest", ":app:connectedDebugAndroidTest")
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -82,6 +82,7 @@ google-cast-framework = { group = "com.google.android.gms", name = "play-service
 
 # Navigation & Data
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigation" }
+androidx-navigation-testing = { group = "androidx.navigation", name = "navigation-testing", version.ref = "navigation" }
 androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
 androidx-security-crypto = { group = "androidx.security", name = "security-crypto", version.ref = "security" }
 androidx-biometric = { group = "androidx.biometric", name = "biometric", version.ref = "biometric" }


### PR DESCRIPTION
## Summary
- add unit tests for SeasonEpisodesViewModel and DownloadsViewModel using MockK
- add Compose navigation UI test from seasons to episodes
- wire up navigation-testing dependency and CI test task

## Testing
- `./gradlew testDebugUnitTest` *(fails: SDK location not found)*
- `./gradlew connectedDebugAndroidTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a54dbe55d083279cc56a50bfb3d640