### PR TITLE
fix: use stable Android 35 SDK

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,12 +9,12 @@ plugins {
 
 android {
     namespace = "com.example.jellyfinandroid"
-    compileSdk = 35
+    compileSdk = libs.versions.sdk.get().toInt()
 
     defaultConfig {
         applicationId = "com.example.jellyfinandroid"
         minSdk = 26 // Android 8.0+ (was 31) - Broader device compatibility
-        targetSdk = 35
+        targetSdk = libs.versions.sdk.get().toInt()
         versionCode = 1
         versionName = "1.0"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,7 @@ kotlinxCoroutinesTest = "1.10.2"
 androidxArchCoreTest = "2.2.0"
 androidxTvMaterial = "1.1.0-alpha01"
 paging = "3.4.0-alpha02"
+sdk = "35"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }


### PR DESCRIPTION
## Summary
- use Android 35 for compile and target SDK levels to avoid preview 36 issues

## Testing
- `./gradlew testDebugUnitTest` *(fails: SDK location not found)*
- `./gradlew lintDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a777189dac832786dcc75a5ec83fce

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build configuration now uses a centralized SDK version (set to 35) for compile and target, replacing a hard-coded value.
  * No changes to features, UI, or performance; app behavior remains unchanged.
  * This ensures consistent SDK versioning across builds and helps maintain compatibility with current build tooling and app store requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->