### PR TITLE
Remove explicit Compose compiler version

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -59,10 +59,6 @@ android {
         compose = true
         buildConfig = true
     }
-
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.15"
-    }
 }
 
 dependencies {


### PR DESCRIPTION
## Summary
- remove explicit compose compiler version to rely on Kotlin 2.2.10 plugin

## Testing
- `./gradlew testDebugUnitTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a78c0822708327b1641fc06a82d3d7