### PR TITLE
Move subtitles control to bottom bar when tracks available

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/ui/player/VideoPlayerScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/player/VideoPlayerScreen.kt
@@ -494,21 +494,21 @@ private fun VideoControlsOverlay(
                             }
                         }
                     }
-                if (playerState.availableAudioTracks.size > 1) {
-                    IconButton(onClick = onAudioTracksClick) {
-                        Icon(
-                            imageVector = Icons.Default.Audiotrack,
-                            contentDescription = "Audio Tracks",
-                            tint = Color.White,
-                        )
+                    if (playerState.availableAudioTracks.size > 1) {
+                        IconButton(onClick = onAudioTracksClick) {
+                            Icon(
+                                imageVector = Icons.Default.Audiotrack,
+                                contentDescription = "Audio Tracks",
+                                tint = Color.White,
+                            )
+                        }
                     }
-                }
 
-                // Cast button with device selection
-                CastButton(
-                    isCasting = playerState.isCasting,
-                    onClick = onCastClick,
-                )
+                    // Cast button with device selection
+                    CastButton(
+                        isCasting = playerState.isCasting,
+                        onClick = onCastClick,
+                    )
                     ControlButton(
                         onClick = onPictureInPictureClick,
                         imageVector = Icons.Default.PictureInPicture,


### PR DESCRIPTION
## Summary
- Show subtitles icon in controls only if subtitle tracks exist
- Relocate subtitles button to bottom control bar next to playback controls

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f4d6b6b4832785a67c8846ea950b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * The subtitles control has been moved from the top control bar to the bottom progress/controls area.
  * The Subtitles button now only appears when subtitle tracks are available.
  * Visual icon and tap behavior for subtitles remain unchanged.
  * No other visible changes to playback controls or player behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->