### PR TITLE
Use theme-aware colors for carousel overlays

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/home/HomeCarousel.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/home/HomeCarousel.kt
@@ -261,32 +261,32 @@ private fun CarouselContentCard(
                 when (item.type?.toString()) {
                     "Episode" -> {
                         item.seriesName?.let { seriesName ->
-                                Text(
-                                    text = seriesName,
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
-                                    maxLines = 1,
-                                )
+                            Text(
+                                text = seriesName,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
+                                maxLines = 1,
+                            )
                         }
                     }
                     "Series" -> {
                         item.productionYear?.let { year ->
-                                Text(
-                                    text = year.toString(),
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
-                                    maxLines = 1,
-                                )
+                            Text(
+                                text = year.toString(),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
+                                maxLines = 1,
+                            )
                         }
                     }
                     "Audio" -> {
                         item.artists?.firstOrNull()?.let { artist ->
-                                Text(
-                                    text = artist,
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
-                                    maxLines = 1,
-                                )
+                            Text(
+                                text = artist,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
+                                maxLines = 1,
+                            )
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- Use `onPrimary` for rating badge text
- Use `onSurface` for title and details
- Remove hardcoded white overlay colors to adapt to theme variations

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa1e611bec8327ae13466d298ab1ac

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Updated Home carousel to use Material 3 theme colors for titles, rating badges, and metadata, improving consistency across light and dark modes.
  - Adjusted text opacities for secondary details to enhance readability.
  - Refined spacing in content cards (reduced vertical gaps) for a denser, cleaner layout.
  - Applies to movie and content cards without changing behavior or interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->