### PR TITLE
refactor: use theme colors for expressive cards

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/ui/components/ExpressiveCards.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/components/ExpressiveCards.kt
@@ -202,7 +202,7 @@ private fun MediaCardContent(
                         Brush.verticalGradient(
                             colors = listOf(
                                 MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0f),
-                                MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f),
+                                Color.Transparent,
                             ),
                             startY = 120f,
                         ),


### PR DESCRIPTION
## Summary
- replace hardcoded black/white overlays with theme surface variants
- update rating and action icons to use themed colors
- show favorites using theme error color instead of red

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa1e61313883279018d38e35a11d72

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated card visuals to use Material theme colors instead of hard-coded values.
  * Refreshed gradient overlays, rating badges, star icons, action icon tints, text, and favorite indicator to be theme-aware.
  * Improved contrast and readability across light/dark modes.
  * Visual-only changes; no behavior or API impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->