### PR TITLE
Display season watch status badges

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/TVSeasonScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/TVSeasonScreen.kt
@@ -30,8 +30,8 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.Tv
 import androidx.compose.material3.Badge


### PR DESCRIPTION
## Summary
- Show unwatched episode count badge on season posters
- Replace badge with checkmark when season is fully watched

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abd3f5e3648327a4c109de78ce35c8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Season cards now support multiple top-right indicators simultaneously.
  * Shows a favorite star for marked seasons.
  * Displays an unplayed episodes badge (capped at “99+”) when there are remaining episodes.
  * Shows a checkmark badge when all episodes are watched and none are unplayed.
  * Improves at-a-glance status for each season without altering the existing layout or typography.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->