### PR TITLE
Cap genre badge width in MovieDetailScreen

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/MovieDetailScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/MovieDetailScreen.kt
@@ -602,7 +602,7 @@ private fun ExpressiveMovieInfoCard(
                                     overflow = TextOverflow.Ellipsis,
                                     modifier = Modifier
                                         .padding(horizontal = 12.dp, vertical = 6.dp)
-                                        .widthIn(max = 120.dp),
+                                        .widthIn(max = GenreBadgeMaxWidth),
                                 )
                             }
                         }


### PR DESCRIPTION
## Summary
- Ensure genre badges truncate to a single line with ellipsis
- Limit genre badge width to avoid oversized chips

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abd7eb50e083279fce63f285ffbea4