### PR TITLE
Add cast device discovery and selection

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/ui/player/CastManager.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/player/CastManager.kt
@@ -9,6 +9,7 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.MimeTypes
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
+import androidx.mediarouter.media.MediaRouter
 import com.google.android.gms.cast.MediaInfo
 import com.google.android.gms.cast.MediaLoadRequestData
 import com.google.android.gms.cast.framework.CastContext
@@ -158,6 +159,33 @@ class CastManager @Inject constructor(
             } catch (e: Exception) {
                 Log.e("CastManager", "Failed to initialize Cast", e)
             }
+        }
+    }
+
+    /**
+     * Discover available Cast devices on the local network.
+     * Returns a list of friendly device names.
+     */
+    fun discoverDevices(): List<String> {
+        val router = MediaRouter.getInstance(context)
+        val selector = castContext?.mergedSelector
+        return router.routes
+            .filter { selector?.matchesControlFilters(it) == true }
+            .map { it.name }
+    }
+
+    /**
+     * Connect to the specified Cast device by name.
+     * Returns true if a matching device was found and selected.
+     */
+    fun connectToDevice(deviceName: String): Boolean {
+        val router = MediaRouter.getInstance(context)
+        val route = router.routes.firstOrNull { it.name == deviceName }
+        return if (route != null) {
+            router.selectRoute(route)
+            true
+        } else {
+            false
         }
     }
 

--- a/app/src/main/java/com/rpeters/jellyfin/ui/player/VideoPlayerViewModel.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/player/VideoPlayerViewModel.kt
@@ -79,7 +79,12 @@ data class VideoPlayerState(
 class VideoPlayerViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
     private val repository: JellyfinRepository,
+    private val castManager: CastManager,
 ) : ViewModel() {
+
+    init {
+        castManager.initialize()
+    }
 
     private val _playerState = MutableStateFlow(VideoPlayerState())
     val playerState: StateFlow<VideoPlayerState> = _playerState.asStateFlow()
@@ -253,14 +258,27 @@ class VideoPlayerViewModel @Inject constructor(
     fun changeAspectRatio(aspectRatio: AspectRatioMode) {
         _playerState.value = _playerState.value.copy(selectedAspectRatio = aspectRatio)
     }
-    fun showCastDialog() { /* Not implemented yet */ }
+    fun showCastDialog() {
+        val devices = castManager.discoverDevices()
+        _playerState.value = _playerState.value.copy(
+            availableCastDevices = devices,
+            showCastDialog = true,
+        )
+    }
     fun showSubtitleDialog() { /* Not implemented yet */ }
     fun selectAudioTrack(track: TrackInfo) { /* Not implemented yet */ }
     fun selectSubtitleTrack(track: TrackInfo?) { /* Not implemented yet */ }
     fun hideSubtitleDialog() {
         _playerState.value = _playerState.value.copy(showSubtitleDialog = false)
     }
-    fun selectCastDevice(deviceName: String) { /* Not implemented yet */ }
+    fun selectCastDevice(deviceName: String) {
+        val connected = castManager.connectToDevice(deviceName)
+        _playerState.value = _playerState.value.copy(
+            isCasting = connected,
+            castDeviceName = if (connected) deviceName else null,
+            showCastDialog = false,
+        )
+    }
     fun hideCastDialog() {
         _playerState.value = _playerState.value.copy(showCastDialog = false)
     }


### PR DESCRIPTION
## Summary
- add MediaRouter-based device discovery and connection helpers in `CastManager`
- inject `CastManager` into `VideoPlayerViewModel` and expose cast device discovery/selection

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abdfac38ac8327a5deecb9f911c175

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cast device discovery from the video player, showing a dialog with available devices.
  * Enabled selecting a device to start casting directly from the app.
  * Display now reflects the active cast device and casting status.
  * Handles cases with no available devices gracefully, allowing the dialog to close without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->