### PR TITLE
Defer video seek until slider release with preview

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/ui/player/ExpressiveVideoControls.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/player/ExpressiveVideoControls.kt
@@ -370,13 +370,15 @@ private fun ExpressiveBottomControls(
                             ),
                         )
 
+                        val textMeasurer = rememberTextMeasurer()
                         if (isDragging) {
                             val previewText = formatTime(previewPosition)
-                            val textMeasurer = rememberTextMeasurer()
-                            val textLayout = textMeasurer.measure(
-                                text = AnnotatedString(previewText),
-                                style = MaterialTheme.typography.bodySmall,
-                            )
+                            val textLayout = remember(previewText, MaterialTheme.typography.bodySmall) {
+                                textMeasurer.measure(
+                                    text = AnnotatedString(previewText),
+                                    style = MaterialTheme.typography.bodySmall,
+                                )
+                            }
                             val textWidth = with(LocalDensity.current) {
                                 textLayout.size.width.toDp()
                             }


### PR DESCRIPTION
## Summary
- track slider drag separately from finished state to defer seeking until release
- show preview time above slider thumb while dragging and reflect tentative time

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abe0c2a3f083279db5e1e04b493a06