### PR TITLE
Start playback automatically

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/ui/player/VideoPlayerViewModel.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/player/VideoPlayerViewModel.kt
@@ -194,6 +194,10 @@ class VideoPlayerViewModel @Inject constructor(
                     // Set media and prepare
                     exoPlayer?.setMediaItem(mediaItem)
                     exoPlayer?.prepare()
+                    exoPlayer?.play()
+
+                    // Update state so UI hides controls after timeout
+                    _playerState.value = _playerState.value.copy(isPlaying = true)
 
                     // Seek to start position if specified
                     if (startPosition > 0) {


### PR DESCRIPTION
## Summary
- Auto-start ExoPlayer playback after preparation
- Update view state to reflect playing so controls hide when expected

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abe0c575d88327b758f8ca37f30184