### PR TITLE
Set default aspect ratio to FIT

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/ui/player/VideoPlayerScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/player/VideoPlayerScreen.kt
@@ -575,7 +575,7 @@ private fun VideoControlsOverlay(
                             onClick = { onShowAspectRatioMenu(true) },
                             imageVector = Icons.Default.AspectRatio,
                             contentDescription = "Aspect Ratio: ${playerState.selectedAspectRatio.label}",
-                            tint = if (playerState.selectedAspectRatio != AspectRatioMode.FILL) {
+                            tint = if (playerState.selectedAspectRatio != AspectRatioMode.FIT) {
                                 MaterialTheme.colorScheme.primary
                             } else {
                                 Color.White

--- a/app/src/main/java/com/rpeters/jellyfin/ui/player/VideoPlayerViewModel.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/player/VideoPlayerViewModel.kt
@@ -58,7 +58,7 @@ data class VideoPlayerState(
     val itemId: String = "",
     val itemName: String = "",
     val aspectRatio: Float = 16f / 9f,
-    val selectedAspectRatio: AspectRatioMode = AspectRatioMode.FILL,
+    val selectedAspectRatio: AspectRatioMode = AspectRatioMode.FIT,
     val availableAspectRatios: List<AspectRatioMode> = AspectRatioMode.values().toList(),
     val isControlsVisible: Boolean = true,
     val showSubtitleDialog: Boolean = false,


### PR DESCRIPTION
## Summary
- default `selectedAspectRatio` to `AspectRatioMode.FIT`
- update aspect ratio control tint to treat FIT as baseline

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abe0c7f28c8327a72eb1a39b04362e