### PR TITLE
Use CollectionType enum for library routing

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/navigation/NavGraph.kt
@@ -673,7 +673,6 @@ private fun libraryRouteFor(library: BaseItemDto): String? {
         CollectionType.MOVIES -> Screen.Movies.route
         CollectionType.TVSHOWS -> Screen.TVShows.route
         CollectionType.MUSIC -> Screen.Music.route
-        CollectionType.HOMEVIDEOS -> library.id?.toString()?.let { Screen.Stuff.createRoute(it) }
         else -> library.id?.toString()?.let { Screen.Stuff.createRoute(it) }
     }
 }


### PR DESCRIPTION
## Summary
- Compare `BaseItemDto.collectionType` directly against `CollectionType` values when determining navigation
- Route HOMEVIDEOS libraries to the Stuff screen

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abe2fa1ae48327adca41bf5eab2510