### PR TITLE
Use constant for genre badge max width

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/MovieDetailScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/MovieDetailScreen.kt
@@ -607,7 +607,7 @@ private fun ExpressiveMovieInfoCard(
                                     overflow = TextOverflow.Ellipsis,
                                     modifier = Modifier
                                         .padding(horizontal = 12.dp, vertical = 6.dp)
-                                        .widthIn(max = GenreBadgeMaxWidth),
+                                        .widthIn(max = GENRE_BADGE_MAX_WIDTH),
                                 )
                             }
                         }


### PR DESCRIPTION
## Summary
- fix MovieDetailScreen to use `GENRE_BADGE_MAX_WIDTH` constant for genre badge layout

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abe5d9d7f08327aee34314d84fda16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Standardized the internal constant naming for the genre badge width on the movie detail screen to improve consistency and maintainability.
  - No functional or behavioral changes; the width value and layout remain exactly the same.
  - Users should not notice any differences in appearance or interaction. No action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->