### PR TITLE
feat: add floating bottom nav style

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/ui/components/BottomNavBar.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/components/BottomNavBar.kt
@@ -1,11 +1,19 @@
 package com.rpeters.jellyfin.ui.components
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination
 import androidx.navigation.NavDestination.Companion.hierarchy
@@ -22,13 +30,26 @@ fun BottomNavBar(
 
     // Only show bottom nav for main screens
     if (shouldShowBottomNav(currentDestination)) {
-        NavigationBar {
-            BottomNavItem.bottomNavItems.forEach { item ->
-                AddItem(
-                    screen = item,
-                    currentDestination = currentDestination,
-                    navController = navController,
+        Box(
+            modifier = Modifier
+                .padding(16.dp)
+                .shadow(
+                    elevation = 3.dp,
+                    shape = RoundedCornerShape(28.dp),
                 )
+                .clip(RoundedCornerShape(28.dp)),
+        ) {
+            NavigationBar(
+                containerColor = MaterialTheme.colorScheme.surface,
+                tonalElevation = 3.dp,
+            ) {
+                BottomNavItem.bottomNavItems.forEach { item ->
+                    AddItem(
+                        screen = item,
+                        currentDestination = currentDestination,
+                        navController = navController,
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- Wrap NavigationBar in a padded, clipped Box to create a floating Material look.
- Apply shadow and tonal elevation with surface color for Material 3 style.
- Preserve conditional visibility using shouldShowBottomNav.

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9326f0c48327886b7851205e2afa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Bottom navigation bar now sits within a raised, rounded container with subtle shadow and padding for improved visual separation.
  - Updated to use surface-toned colors with tonal elevation for better contrast across light and dark themes.
  - Item layout remains the same; only visual presentation has been enhanced.

- **Chores**
  - Internal adjustments to support the new styling without changing the public API or interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->