### PR TITLE
Handle token refresh for recently added items

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/data/repository/JellyfinMediaRepository.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/data/repository/JellyfinMediaRepository.kt
@@ -338,14 +338,16 @@ class JellyfinMediaRepository @Inject constructor(
             val userUuid = parseUuid(server.userId ?: "", "user")
             val client = getClient(server.url, server.accessToken)
 
-            val response = client.itemsApi.getItems(
-                userId = userUuid,
-                recursive = true,
-                includeItemTypes = listOf(itemType),
-                sortBy = listOf(ItemSortBy.DATE_CREATED),
-                sortOrder = listOf(SortOrder.DESCENDING),
-                limit = limit,
-            )
+            val response = executeWithTokenRefresh {
+                client.itemsApi.getItems(
+                    userId = userUuid,
+                    recursive = true,
+                    includeItemTypes = listOf(itemType),
+                    sortBy = listOf(ItemSortBy.DATE_CREATED),
+                    sortOrder = listOf(SortOrder.DESCENDING),
+                    limit = limit,
+                )
+            }
             response.content.items ?: emptyList()
         }
 


### PR DESCRIPTION
## Summary
- wrap getRecentlyAddedByType API call in executeWithTokenRefresh so expired tokens trigger re-authentication

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aea28971188327963e2d850094432d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when viewing Recently Added items filtered by type, reducing intermittent authentication errors.
  - Automatically recovers from expired sessions during background fetches, minimizing failed loads and retries.
  - Ensures more consistent population of Recently Added lists without requiring user intervention.
  - Enhances overall stability of media fetching in scenarios with transient auth issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->