### PR TITLE
refactor: generalize home videos loader

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/HomeVideosScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/HomeVideosScreen.kt
@@ -69,7 +69,7 @@ fun HomeVideosScreen(
             if (BuildConfig.DEBUG) {
                 android.util.Log.d("HomeVideosScreen", "Loading home videos for library: $libraryId")
             }
-            viewModel.loadHomeVideos(libraryId.toString())
+            viewModel.loadStuffLibrary(libraryId.toString(), "homevideos")
         }
     }
 

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/StuffScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/StuffScreen.kt
@@ -51,9 +51,12 @@ fun StuffScreen(
     val appState by viewModel.appState.collectAsState()
     LaunchedEffect(libraryId) {
         if (BuildConfig.DEBUG) {
-            android.util.Log.d("StuffScreen", "LaunchedEffect triggered for libraryId=$libraryId")
+            android.util.Log.d(
+                "StuffScreen",
+                "LaunchedEffect triggered for libraryId=$libraryId",
+            )
         }
-        viewModel.loadHomeVideos(libraryId)
+        viewModel.loadStuffLibrary(libraryId, collectionType)
     }
 
     val librariesById = remember(appState.libraries) {

--- a/app/src/test/java/com/rpeters/jellyfin/ui/viewmodel/MainAppViewModelHomeVideosTest.kt
+++ b/app/src/test/java/com/rpeters/jellyfin/ui/viewmodel/MainAppViewModelHomeVideosTest.kt
@@ -89,11 +89,27 @@ class MainAppViewModelHomeVideosTest {
         val itemA = BaseItemDto(id = UUID.randomUUID(), name = "A", type = BaseItemKind.VIDEO)
         val itemB = BaseItemDto(id = UUID.randomUUID(), name = "B", type = BaseItemKind.VIDEO)
 
-        coEvery { mediaRepository.getLibraryItems(parentId = libraryA, itemTypes = any(), startIndex = any(), limit = any()) } returns ApiResult.Success(listOf(itemA))
-        coEvery { mediaRepository.getLibraryItems(parentId = libraryB, itemTypes = any(), startIndex = any(), limit = any()) } returns ApiResult.Success(listOf(itemB))
+        coEvery {
+            mediaRepository.getLibraryItems(
+                parentId = libraryA,
+                itemTypes = any(),
+                startIndex = any(),
+                limit = any(),
+                collectionType = any(),
+            )
+        } returns ApiResult.Success(listOf(itemA))
+        coEvery {
+            mediaRepository.getLibraryItems(
+                parentId = libraryB,
+                itemTypes = any(),
+                startIndex = any(),
+                limit = any(),
+                collectionType = any(),
+            )
+        } returns ApiResult.Success(listOf(itemB))
 
-        viewModel.loadHomeVideos(libraryA)
-        viewModel.loadHomeVideos(libraryB)
+        viewModel.loadStuffLibrary(libraryA, "homevideos")
+        viewModel.loadStuffLibrary(libraryB, "homevideos")
         dispatcher.scheduler.advanceUntilIdle()
 
         val state = viewModel.appState.value


### PR DESCRIPTION
## Summary
- rename home video loader to `loadStuffLibrary` with flexible `collectionType`
- select "Video" or "Photo" item types based on collection type
- pass collection type through Stuff and HomeVideos screens

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb83962ec8327962cc2192e44fbe2