### PR TITLE
Load music library data on MusicScreen

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/MusicScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/MusicScreen.kt
@@ -115,10 +115,13 @@ fun MusicScreen(
     var viewMode by remember { mutableStateOf(MusicViewMode.GRID) }
     var showSortMenu by remember { mutableStateOf(false) }
 
-    // Filter music items from recently added types data (this is where the music data actually is)
-    val musicItems = remember(appState.recentlyAddedByTypes) {
-        appState.recentlyAddedByTypes["AUDIO"] ?: emptyList()
+    // Load music library data when the screen is first composed
+    LaunchedEffect(Unit) {
+        viewModel.loadLibraryTypeData(LibraryType.MUSIC)
     }
+
+    // Get music items from the view model's library data and filter/sort locally
+    val musicItems = viewModel.getLibraryTypeData(LibraryType.MUSIC)
 
     // Apply filtering and sorting
     val filteredAndSortedMusic = remember(musicItems, selectedFilter, sortOrder) {


### PR DESCRIPTION
## Summary
- Load music library data when MusicScreen composes
- Source music items from view model library data and filter/sort locally

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb83a642883278e533c75c626b523