### PR TITLE
Add refreshClient helper and update token handling

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/data/repository/JellyfinAuthRepository.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/data/repository/JellyfinAuthRepository.kt
@@ -395,7 +395,7 @@ class JellyfinAuthRepository @Inject constructor(
             _isAuthenticating.value = true
 
             // Clear any cached clients before re-authenticating
-            clientFactory.refreshClient(server.url, server.accessToken)
+            clientFactory.invalidateClient()
 
             // Get saved password for the current server and username
             // Use the stored original server URL for credential lookup, fallback to extracting from current URL

--- a/app/src/main/java/com/rpeters/jellyfin/data/repository/common/BaseJellyfinRepository.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/data/repository/common/BaseJellyfinRepository.kt
@@ -57,10 +57,8 @@ open class BaseJellyfinRepository @Inject constructor(
                     val refreshResult = authRepository.reAuthenticate()
                     if (refreshResult) {
                         Logger.d(LogCategory.NETWORK, javaClass.simpleName, "Proactive token refresh successful")
-                        val currentServer = authRepository.getCurrentServer()
-                        val newToken = currentServer?.accessToken
-                        if (currentServer != null) {
-                            clientFactory.refreshClient(currentServer.url, newToken)
+                        authRepository.getCurrentServer()?.let { server ->
+                            clientFactory.refreshClient(server.url, server.accessToken)
                         }
                     } else {
                         Logger.w(LogCategory.NETWORK, javaClass.simpleName, "Proactive token refresh failed")


### PR DESCRIPTION
## Summary
- add suspend refreshClient to rebuild Jellyfin ApiClient
- use refreshClient after token refresh instead of invalidateClient
- refresh clients on auth repository re-authentication and logout

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b084d70e1c832787818bf96bb8df66

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Fewer unexpected logouts by improving token refresh and client refresh behavior.
  * Seamless re-authentication when credentials change or renew.
  * Logout now reliably clears stored credentials to prevent stale sessions.
  * Reduced connectivity interruptions by promptly refreshing the server connection when tokens update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->