### PR TITLE
Ensure repositories validate tokens before requests

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/data/repository/common/BaseJellyfinRepository.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/data/repository/common/BaseJellyfinRepository.kt
@@ -173,9 +173,8 @@ open class BaseJellyfinRepository @Inject constructor(
         maxAttempts: Int = 3,
         block: suspend () -> T,
     ): ApiResult<T> {
-        validateTokenAndRefreshIfNeeded()
-
         return RetryManager.withRetry(maxAttempts, operationName) { attempt ->
+            validateTokenAndRefreshIfNeeded()
             try {
                 ApiResult.Success(block())
             } catch (e: Exception) {


### PR DESCRIPTION
## Summary
- validate token and refresh if needed at start of all repository execution helpers

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b084d7f60c8327827db24157f349a8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication stability by proactively validating and refreshing your session token before any server requests, including retried and cached requests. This reduces intermittent authorization errors, unexpected logouts, and failed operations—resulting in more reliable browsing, playback, and sync. Fewer manual retries are needed, and background updates continue smoothly without altering existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->