### PR TITLE
refactor: auto refresh tokens for execute

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/data/repository/common/BaseJellyfinRepository.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/data/repository/common/BaseJellyfinRepository.kt
@@ -175,9 +175,9 @@ open class BaseJellyfinRepository @Inject constructor(
         block: suspend () -> T,
     ): ApiResult<T> {
         return RetryManager.withRetry(maxAttempts, operationName) { attempt ->
-            validateTokenAndRefreshIfNeeded()
             try {
-                ApiResult.Success(block())
+                val result = executeWithTokenRefresh { block() }
+                ApiResult.Success(result)
             } catch (e: Exception) {
                 Logger.e(
                     LogCategory.NETWORK,
@@ -201,11 +201,10 @@ open class BaseJellyfinRepository @Inject constructor(
         circuitBreakerKey: String = operationName,
         block: suspend () -> T,
     ): ApiResult<T> {
-        validateTokenAndRefreshIfNeeded()
-
         return RetryManager.withRetryAndCircuitBreaker(maxAttempts, operationName, circuitBreakerKey) { attempt ->
             try {
-                ApiResult.Success(block())
+                val result = executeWithTokenRefresh { block() }
+                ApiResult.Success(result)
             } catch (e: Exception) {
                 Logger.e(
                     LogCategory.NETWORK,
@@ -230,8 +229,6 @@ open class BaseJellyfinRepository @Inject constructor(
         cacheTtlMs: Long = 30 * 60 * 1000L, // 30 minutes default
         block: suspend () -> List<BaseItemDto>,
     ): ApiResult<List<BaseItemDto>> {
-        validateTokenAndRefreshIfNeeded()
-
         // Try cache first
         val cachedData = cache.getCachedItems(cacheKey)
         if (cachedData != null) {
@@ -257,8 +254,6 @@ open class BaseJellyfinRepository @Inject constructor(
         cacheTtlMs: Long = 30 * 60 * 1000L,
         block: suspend () -> List<BaseItemDto>,
     ): ApiResult<List<BaseItemDto>> {
-        validateTokenAndRefreshIfNeeded()
-
         // Invalidate existing cache
         cache.invalidateCache(cacheKey)
 


### PR DESCRIPTION
## Summary
- use executeWithTokenRefresh inside execute() for consistent token refresh and retry behavior

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0935eb550832795803bdd44aedbc5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fewer failed requests and automatic retry when authorization expires, reducing unexpected sign-outs or prompts.

* **Performance & Reliability**
  * Centralized, concurrency-safe token refresh improves request reliability and prevents duplicate refresh attempts under load.
  * Short delay to ensure refreshed tokens propagate before retrying requests.

* **Documentation**
  * Clarified proactive token validation and 401-aware retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->