### PR TITLE
Increase disk cache to 150 MB

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/di/NetworkModule.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/di/NetworkModule.kt
@@ -46,7 +46,7 @@ object NetworkModule {
         connectivityChecker: ConnectivityChecker,
     ): OkHttpClient {
         val cacheDir = java.io.File(context.cacheDir, "http_cache")
-        val cache = okhttp3.Cache(cacheDir, 20L * 1024 * 1024) // 20 MB
+        val cache = okhttp3.Cache(cacheDir, 150L * 1024 * 1024) // 150 MB
 
         val authInterceptor = okhttp3.Interceptor { chain ->
             val originalRequest = chain.request()


### PR DESCRIPTION
## Summary
- Increase OkHttp disk cache from 20 MB to 150 MB to prevent artwork churn on larger lists.

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ec25835883279eea595aa5f1ef6b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Increased the app’s HTTP cache from 20 MB to 150 MB to improve performance and reliability.
  - Users should see faster repeat loads (images, artwork, metadata), smoother browsing, and reduced data usage.
  - Helps content load more consistently on slow or intermittent connections.
  - No user action required; this enhancement works automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->