### PR TITLE
perf: memoize home screen lists

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/HomeScreen.kt
@@ -209,6 +209,30 @@ fun HomeContent(
             }
         }
     }
+
+    // Cache heavy computations and derived lists to minimize recomposition
+    val continueWatchingItems by remember(appState.allItems) {
+        derivedStateOf { getContinueWatchingItems(appState) }
+    }
+    val recentMovies by remember(appState.recentlyAddedByTypes) {
+        derivedStateOf { appState.recentlyAddedByTypes["MOVIE"]?.take(8) ?: emptyList() }
+    }
+    val recentTVShows by remember(appState.recentlyAddedByTypes) {
+        derivedStateOf { appState.recentlyAddedByTypes["SERIES"]?.take(8) ?: emptyList() }
+    }
+    val featuredItems by remember(appState.recentlyAddedByTypes) {
+        derivedStateOf { (recentMovies + recentTVShows).take(10) }
+    }
+    val recentEpisodes by remember(appState.recentlyAddedByTypes) {
+        derivedStateOf { appState.recentlyAddedByTypes["EPISODE"]?.take(15) ?: emptyList() }
+    }
+    val recentMusic by remember(appState.recentlyAddedByTypes) {
+        derivedStateOf { appState.recentlyAddedByTypes["AUDIO"]?.take(15) ?: emptyList() }
+    }
+    val recentVideos by remember(appState.recentlyAddedByTypes) {
+        derivedStateOf { appState.recentlyAddedByTypes["VIDEO"]?.take(15) ?: emptyList() }
+    }
+
     Box(
         modifier = modifier,
     ) {
@@ -219,7 +243,6 @@ fun HomeContent(
             item { HomeHeader(currentServer) }
 
             // Continue Watching Section
-            val continueWatchingItems = getContinueWatchingItems(appState)
             if (continueWatchingItems.isNotEmpty()) {
                 item {
                     ContinueWatchingSection(
@@ -229,10 +252,6 @@ fun HomeContent(
                     )
                 }
             }
-
-            val recentMovies = appState.recentlyAddedByTypes["MOVIE"]?.take(8) ?: emptyList()
-            val recentTVShows = appState.recentlyAddedByTypes["SERIES"]?.take(8) ?: emptyList()
-            val featuredItems = (recentMovies + recentTVShows).take(10)
 
             if (featuredItems.isNotEmpty()) {
                 item {
@@ -279,7 +298,6 @@ fun HomeContent(
                 }
             }
 
-            val recentEpisodes = appState.recentlyAddedByTypes["EPISODE"]?.take(15) ?: emptyList()
             if (recentEpisodes.isNotEmpty()) {
                 item {
                     EnhancedContentCarousel(
@@ -293,7 +311,6 @@ fun HomeContent(
                 }
             }
 
-            val recentMusic = appState.recentlyAddedByTypes["AUDIO"]?.take(15) ?: emptyList()
             if (recentMusic.isNotEmpty()) {
                 item {
                     EnhancedContentCarousel(
@@ -307,7 +324,6 @@ fun HomeContent(
                 }
             }
 
-            val recentVideos = appState.recentlyAddedByTypes["VIDEO"]?.take(15) ?: emptyList()
             if (recentVideos.isNotEmpty()) {
                 item {
                     EnhancedContentCarousel(


### PR DESCRIPTION
## Summary
- cache continue watching items using `derivedStateOf`
- memoize recently-added lists with `remember(appState.recentlyAddedByTypes)`
- reduce unnecessary recompositions when library data changes

## Testing
- `./gradlew lintDebug testDebugUnitTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b47d39eabc83278a35f4baf12035d7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized Home screen rendering by caching derived lists for Continue Watching, Recently Added (Movies, TV Shows, Episodes, Music, Videos), and Featured items.
  * Reduces unnecessary recompositions, improving scroll smoothness and responsiveness, especially with large libraries or rapid updates.
  * No changes to visuals, layout, or conditional behavior; UI remains identical.
  * May lower CPU usage and battery consumption while browsing the Home tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->