### PR TITLE
perf: simplify carousels with LazyRow

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/home/HomeCarousel.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/home/HomeCarousel.kt
@@ -1,31 +1,31 @@
 package com.rpeters.jellyfin.ui.screens.home
 
-import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.carousel.HorizontalMultiBrowseCarousel
-import androidx.compose.material3.carousel.HorizontalUncontainedCarousel
-import androidx.compose.material3.carousel.rememberCarouselState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -36,7 +36,7 @@ import com.rpeters.jellyfin.ui.image.ImageSize
 import com.rpeters.jellyfin.ui.image.OptimizedImage
 import org.jellyfin.sdk.model.api.BaseItemDto
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun HomeCarousel(
     movies: List<BaseItemDto>,
@@ -51,25 +51,28 @@ fun HomeCarousel(
             style = MaterialTheme.typography.headlineSmall,
             modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
         )
-        val carouselState = rememberCarouselState { movies.size }
-        HorizontalUncontainedCarousel(
-            state = carouselState,
+        val listState = rememberLazyListState()
+        val flingBehavior = rememberSnapFlingBehavior(lazyListState = listState)
+        LazyRow(
+            state = listState,
+            flingBehavior = flingBehavior,
+            contentPadding = PaddingValues(horizontal = 16.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
             modifier = Modifier
                 .fillMaxWidth()
                 .height(240.dp),
-            itemWidth = 280.dp,
-            itemSpacing = 12.dp,
-            contentPadding = PaddingValues(horizontal = 16.dp),
-        ) { index ->
-            val movie = movies[index]
-            CarouselMovieCard(
-                movie = movie,
-                getBackdropUrl = getBackdropUrl,
-                onClick = onItemClick,
-                modifier = Modifier
-                    .fillMaxSize()
-                    .clip(RoundedCornerShape(16.dp)),
-            )
+        ) {
+            items(movies, key = { it.id }) { movie ->
+                CarouselMovieCard(
+                    movie = movie,
+                    getBackdropUrl = getBackdropUrl,
+                    onClick = onItemClick,
+                    modifier = Modifier
+                        .width(280.dp)
+                        .fillMaxHeight()
+                        .clip(RoundedCornerShape(16.dp)),
+                )
+            }
         }
     }
 }
@@ -137,7 +140,7 @@ private fun CarouselMovieCard(
  * Enhanced Material 3 Expressive Carousel for all content types
  * Supports Movies, TV Shows, Episodes, Music, and more
  */
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun EnhancedContentCarousel(
     items: List<BaseItemDto>,
@@ -156,51 +159,40 @@ fun EnhancedContentCarousel(
             style = MaterialTheme.typography.headlineSmall,
             modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
         )
-        val carouselState = rememberCarouselState(initialItem = 1) { items.size }
-        HorizontalMultiBrowseCarousel(
-            state = carouselState,
-            preferredItemWidth = 220.dp,
+        val listState = rememberLazyListState()
+        val flingBehavior = rememberSnapFlingBehavior(lazyListState = listState)
+        LazyRow(
+            state = listState,
+            flingBehavior = flingBehavior,
+            contentPadding = PaddingValues(horizontal = 64.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
             modifier = Modifier
                 .fillMaxWidth()
                 .height(360.dp),
-            itemSpacing = 16.dp,
-            contentPadding = PaddingValues(horizontal = 64.dp),
-        ) { index ->
-            val item = items[index]
-            val info = carouselItemDrawInfo
-            val progress by animateFloatAsState(
-                targetValue = if (info.maxSize == 0f) 0f else info.size / info.maxSize,
-                label = "carousel_item_scale",
-            )
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .graphicsLayer {
-                        val scale = 0.85f + (0.15f * progress)
-                        scaleX = scale
-                        scaleY = scale
-                    },
-            ) {
+        ) {
+            items(items, key = { it.id }) { item ->
                 ExpressiveMediaCard(
                     title = item.name ?: "Unknown Title",
                     subtitle = when (item.type?.toString()) {
-                        "Episode" -> item.seriesName ?: ""
-                        "Series" -> item.productionYear?.toString() ?: ""
-                        "Audio" -> item.artists?.firstOrNull() ?: ""
-                        "Movie" -> item.productionYear?.toString() ?: ""
-                        else -> ""
+                        "Episode" -> item.seriesName ?: "",
+                        "Series" -> item.productionYear?.toString() ?: "",
+                        "Audio" -> item.artists?.firstOrNull() ?: "",
+                        "Movie" -> item.productionYear?.toString() ?: "",
+                        else -> "",
                     },
                     imageUrl = when (item.type?.toString()) {
-                        "Episode" -> getSeriesImageUrl(item) ?: getImageUrl(item) ?: ""
-                        "Audio", "MusicAlbum" -> getImageUrl(item) ?: ""
-                        "Series" -> getSeriesImageUrl(item) ?: getBackdropUrl(item) ?: getImageUrl(item) ?: ""
-                        else -> getBackdropUrl(item) ?: getImageUrl(item) ?: ""
+                        "Episode" -> getSeriesImageUrl(item) ?: getImageUrl(item) ?: "",
+                        "Audio", "MusicAlbum" -> getImageUrl(item) ?: "",
+                        "Series" -> getSeriesImageUrl(item) ?: getBackdropUrl(item) ?: getImageUrl(item) ?: "",
+                        else -> getBackdropUrl(item) ?: getImageUrl(item) ?: "",
                     },
                     rating = item.communityRating?.toFloat(),
                     onCardClick = { onItemClick(item) },
                     onPlayClick = { onItemClick(item) },
                     cardType = ExpressiveCardType.ELEVATED,
-                    modifier = Modifier.fillMaxSize(),
+                    modifier = Modifier
+                        .width(220.dp)
+                        .fillMaxHeight(),
                 )
             }
         }


### PR DESCRIPTION
## Summary
- replace Material 3 carousels with LazyRow and rememberLazyListState
- add snap fling behavior and stable item keys for smoother scrolling

## Testing
- `./gradlew testDebugUnitTest` *(fails: SDK location not found)*
- `./gradlew lintDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b47d372af0832784e5268e898dc468

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Horizontal carousels now snap to items for smoother, more predictable scrolling.

- Style
  - Updated card sizes and spacing for a cleaner, more consistent layout.
  - Removed per-item zoom animation for a steadier browsing experience.

- Improvements
  - More accurate titles/subtitles and images across content types (movies, series, episodes, audio).
  - Enhanced carousel responsiveness and scrolling feel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->