### PR TITLE
perf: use LazyColumn for library grid section

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/home/LibraryGridSection.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/home/LibraryGridSection.kt
@@ -5,11 +5,14 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Folder
@@ -52,12 +55,13 @@ fun LibraryGridSection(
             modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
         )
 
-        // Use a vertical arrangement for compact cards
-        Column(
-            modifier = Modifier.padding(horizontal = 16.dp),
+        // Use a lazy column for better performance with many libraries
+        LazyColumn(
+            modifier = Modifier.fillMaxWidth(),
+            contentPadding = PaddingValues(horizontal = 16.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            libraries.forEach { library ->
+            items(libraries, key = { it.id ?: it.name }) { library ->
                 ExpressiveCompactCard(
                     title = library.name ?: "Unknown Library",
                     subtitle = library.type?.toString()?.replace("_", " ")?.lowercase()


### PR DESCRIPTION
## Summary
- replace column iteration with LazyColumn in LibraryGridSection
- provide stable item keys for smoother scrolling

## Testing
- `./gradlew testDebugUnitTest` *(fails: SDK location not found)*
- `./gradlew lintDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b47d33a4d08327ad648ca4fbcb64da

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Library cards now display cover images and type-specific icons.
  - Library items are tappable for quicker access.

- Refactor
  - Optimized the home library list for smoother scrolling and better performance with large collections.
  - Improved spacing and padding for a cleaner, more consistent layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->