### PR TITLE
fix: offload network and home loading work to IO dispatcher

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/data/session/JellyfinSessionManager.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/data/session/JellyfinSessionManager.kt
@@ -6,10 +6,12 @@ import com.rpeters.jellyfin.data.JellyfinServer
 import com.rpeters.jellyfin.data.repository.JellyfinAuthRepository
 import com.rpeters.jellyfin.data.utils.RepositoryUtils
 import com.rpeters.jellyfin.di.OptimizedClientFactory
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import org.jellyfin.sdk.api.client.ApiClient
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -65,7 +67,9 @@ class JellyfinSessionManager @Inject constructor(
         val client = getClientForUrl(server.url)
 
         return try {
-            block(server, client)
+            withContext(Dispatchers.IO) {
+                block(server, client)
+            }
         } catch (e: Exception) {
             if (!RepositoryUtils.is401Error(e)) throw e
 
@@ -84,7 +88,9 @@ class JellyfinSessionManager @Inject constructor(
 
             val freshServer = currentServerOrThrow()
             val freshClient = getClientForUrl(freshServer.url)
-            block(freshServer, freshClient)
+            withContext(Dispatchers.IO) {
+                block(freshServer, freshClient)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure session manager executes API calls on `Dispatchers.IO`
- run home data loading and refresh on `viewModelScope.launch(Dispatchers.IO)` with main-thread state updates

## Testing
- `./gradlew lintDebug testDebugUnitTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b47d3255988327b33232ca908c9489