### PR TITLE
feat: normalize server URL for credential storage

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/data/SecureCredentialManager.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/data/SecureCredentialManager.kt
@@ -13,6 +13,7 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import androidx.fragment.app.FragmentActivity
 import com.rpeters.jellyfin.core.constants.Constants
+import com.rpeters.jellyfin.utils.normalizeServerUrl
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
@@ -162,7 +163,8 @@ class SecureCredentialManager @Inject constructor(
 
     // ✅ ENHANCEMENT: Modern secure storage with Android Keystore + DataStore + Key Rotation
     suspend fun savePassword(serverUrl: String, username: String, password: String) {
-        val key = generateKey(serverUrl, username)
+        val normalizedUrl = normalizeServerUrl(serverUrl)
+        val key = generateKey(normalizedUrl, username)
         val encryptedPassword = encrypt(password)
 
         context.secureCredentialsDataStore.edit { preferences ->
@@ -201,7 +203,8 @@ class SecureCredentialManager @Inject constructor(
         }
 
         // Get the password as usual
-        val key = generateKey(serverUrl, username)
+        val normalizedUrl = normalizeServerUrl(serverUrl)
+        val key = generateKey(normalizedUrl, username)
         val encryptedPassword = context.secureCredentialsDataStore.data.map { preferences ->
             preferences[stringPreferencesKey(key)]
         }.first()
@@ -217,7 +220,8 @@ class SecureCredentialManager @Inject constructor(
     }
 
     suspend fun clearPassword(serverUrl: String, username: String) {
-        val key = generateKey(serverUrl, username)
+        val normalizedUrl = normalizeServerUrl(serverUrl)
+        val key = generateKey(normalizedUrl, username)
         context.secureCredentialsDataStore.edit { preferences ->
             preferences.remove(stringPreferencesKey(key))
             preferences.remove(longPreferencesKey("${key}_timestamp"))

--- a/app/src/main/java/com/rpeters/jellyfin/utils/ServerUrlNormalizer.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/utils/ServerUrlNormalizer.kt
@@ -1,0 +1,23 @@
+package com.rpeters.jellyfin.utils
+
+import java.net.URI
+
+/**
+ * Normalize a Jellyfin server URL by trimming whitespace, removing trailing slashes
+ * and forcing lowercase scheme and host parts.
+ */
+fun normalizeServerUrl(input: String): String {
+    var url = input.trim()
+    if (!url.startsWith("http://", ignoreCase = true) && !url.startsWith("https://", ignoreCase = true)) {
+        url = "https://$url"
+    }
+    val uri = URI(url)
+    val scheme = (uri.scheme ?: "https").lowercase()
+    val host = (uri.host ?: uri.authority ?: "").lowercase()
+    val port = if (uri.port != -1) ":${uri.port}" else ""
+    val path = uri.rawPath?.trimEnd('/') ?: ""
+    return buildString {
+        append(scheme).append("://").append(host).append(port)
+        if (path.isNotEmpty()) append(path)
+    }
+}


### PR DESCRIPTION
## Summary
- add server URL normalizer utility to trim trailing slashes and force lowercase
- normalize server URLs for credential storage and re-authentication
- test credential lookup works with URL variants

## Testing
- `./gradlew testDebugUnitTest` *(fails: SDK location not found)*
- `./gradlew lintDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b537cf3824832784ef151323e2cb4a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic server URL normalization for consistent account handling.

* **Bug Fixes**
  * Credentials and sessions are now recognized regardless of URL formatting (scheme, casing, trailing slashes, ports).
  * More reliable login, re-authentication, and logout when the server URL is entered differently across attempts, including biometric unlock flows.

* **Tests**
  * Added tests for URL normalization and cross-variant credential retrieval; removed obsolete tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->