### PR TITLE
fix: refine URL normalization and credential fallback

### DIFF
--- a/URL_NORMALIZATION_FIX.md
+++ b/URL_NORMALIZATION_FIX.md
@@ -36,13 +36,13 @@ private fun normalizeServerUrl(serverUrl: String): String {
 
 ### 2. Consistent Credential Operations
 - **Storage**: `savePassword(normalizeServerUrl(serverUrl), username, password)`
-- **Lookup**: `getPassword(server.originalServerUrl ?: normalizeServerUrl(server.url), username)`
+- **Lookup**: `getPassword(server.normalizedUrl ?: normalizeServerUrl(server.url), username)`
 
 ### 3. Updated JellyfinServer Data Storage
 ```kotlin
 val server = JellyfinServer(
     // ... other fields
-    originalServerUrl = normalizeServerUrl(serverUrl), // Store normalized URL
+    normalizedUrl = normalizeServerUrl(serverUrl),
 )
 ```
 
@@ -51,7 +51,7 @@ val server = JellyfinServer(
 ### JellyfinAuthRepository.kt
 1. **Added `normalizeServerUrl()` function** - Removes port numbers for consistent URL formatting
 2. **Updated `authenticateUser()`** - Uses normalized URL for credential storage
-3. **Updated `reAuthenticate()`** - Uses stored `originalServerUrl` with fallback to normalized current URL
+3. **Updated `reAuthenticate()`** - Uses stored `normalizedUrl` with fallback to normalized current URL
 4. **Enhanced logging** - Shows which URL is used for credential operations
 
 ## Testing Verification
@@ -98,7 +98,7 @@ The fix normalizes URLs by:
 
 ### Error Prevention
 - **Safe parsing** with try/catch blocks
-- **Fallback mechanisms** if `originalServerUrl` is null
+- **Fallback mechanisms** if `normalizedUrl` is null
 - **Enhanced logging** for debugging credential operations
 
 ### Future Considerations

--- a/app/src/main/java/com/rpeters/jellyfin/data/JellyfinServer.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/data/JellyfinServer.kt
@@ -14,8 +14,9 @@ data class JellyfinServer(
     val username: String? = null,
     val accessToken: String? = null,
     val loginTimestamp: Long? = null,
-    // Store the original server URL for credential lookups (without /jellyfin path)
-    val originalServerUrl: String? = null,
+    // Normalized server URL for credential lookups
+    @SerialName("originalServerUrl")
+    val normalizedUrl: String? = null,
 )
 
 @Serializable

--- a/app/src/main/java/com/rpeters/jellyfin/utils/ServerUrlNormalizer.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/utils/ServerUrlNormalizer.kt
@@ -1,6 +1,7 @@
 package com.rpeters.jellyfin.utils
 
 import java.net.URI
+import java.net.URISyntaxException
 
 /**
  * Normalize a Jellyfin server URL by trimming whitespace, removing trailing slashes
@@ -11,13 +12,17 @@ fun normalizeServerUrl(input: String): String {
     if (!url.startsWith("http://", ignoreCase = true) && !url.startsWith("https://", ignoreCase = true)) {
         url = "https://$url"
     }
-    val uri = URI(url)
-    val scheme = (uri.scheme ?: "https").lowercase()
-    val host = (uri.host ?: uri.authority ?: "").lowercase()
-    val port = if (uri.port != -1) ":${uri.port}" else ""
-    val path = uri.rawPath?.trimEnd('/') ?: ""
-    return buildString {
-        append(scheme).append("://").append(host).append(port)
-        if (path.isNotEmpty()) append(path)
+    return try {
+        val uri = URI(url)
+        val scheme = (uri.scheme ?: "https").lowercase()
+        val host = uri.host?.lowercase() ?: ""
+        val port = if (uri.port != -1) ":${uri.port}" else ""
+        val path = uri.rawPath?.trimEnd('/') ?: ""
+        buildString {
+            append(scheme).append("://").append(host).append(port)
+            if (path.isNotEmpty()) append(path)
+        }
+    } catch (_: URISyntaxException) {
+        url
     }
 }

--- a/app/src/test/java/com/rpeters/jellyfin/data/SecureCredentialManagerTest.kt
+++ b/app/src/test/java/com/rpeters/jellyfin/data/SecureCredentialManagerTest.kt
@@ -10,20 +10,11 @@ import org.junit.Test
 class SecureCredentialManagerTest {
     private val context: Context = mockk(relaxed = true)
     private val manager = SecureCredentialManager(context)
-    private val generateKeyMethod = SecureCredentialManager::class.java.getDeclaredMethod(
-        "generateKey",
-        String::class.java,
-        String::class.java,
-    ).apply { isAccessible = true }
-
-    private fun generateKey(url: String, username: String): String {
-        return generateKeyMethod.invoke(manager, url, username) as String
-    }
 
     @Test
     fun `generateKey normalizes server URL`() {
-        val keyA = generateKey("HTTPS://Example.com/", "user")
-        val keyB = generateKey("https://example.com", "user")
+        val keyA = manager.generateKey("HTTPS://Example.com/", "user")
+        val keyB = manager.generateKey("https://example.com", "user")
         assertEquals(keyA, keyB)
     }
 
@@ -36,9 +27,9 @@ class SecureCredentialManagerTest {
         val variantWithSlash = "https://Example.com/"
         val variantUpper = "HTTPS://example.COM"
 
-        store[generateKey(variantWithSlash, username)] = password
+        store[manager.generateKey(variantWithSlash, username)] = password
 
-        val retrieved = store[generateKey(variantUpper, username)]
+        val retrieved = store[manager.generateKey(variantUpper, username)]
         assertEquals(password, retrieved)
     }
 


### PR DESCRIPTION
## Summary

- What does this PR change and why?
- Link related issues (e.g., Closes #123)

## Type of change

- [ ] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no functional change)
- [ ] perf (performance improvement)
- [ ] test (add/fix tests)
- [ ] chore (build, tooling, deps)

## Screenshots/GIFs (UI changes)

<!-- If UI changed, add before/after screenshots or a short GIF. -->

## How to test

```bash
# Build
./gradlew assembleDebug

# Unit tests
./gradlew testDebugUnitTest

# Lint
./gradlew lintDebug

# Coverage (HTML under app/build/reports)
./gradlew jacocoTestReport
```

## Checklist

- [ ] Follows Conventional Commits
- [ ] Branch named appropriately (feature/..., bugfix/..., hotfix/..., docs/...)
- [ ] Tests added/updated where applicable
- [ ] `./gradlew testDebugUnitTest` passes
- [ ] `./gradlew lintDebug` passes
- [ ] Docs updated (README/CHANGELOG as needed)
- [ ] Affected areas and testing notes included



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatically migrates existing saved credentials to a canonical format; no user action required.

- Bug Fixes
  - Prevents login issues caused by URL variants (ports, casing, trailing slashes) by consistently using a normalized server URL.
  - Re-authentication and logout flows now reliably reference the normalized URL.
  - More robust URL parsing with graceful fallback for invalid inputs.

- Documentation
  - Added notes outlining the URL normalization behavior and its impact on stored credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->