### PR TITLE
fix: improve URL normalization and credential migration

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/data/repository/JellyfinAuthRepository.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/data/repository/JellyfinAuthRepository.kt
@@ -129,7 +129,7 @@ class JellyfinAuthRepository @Inject constructor(
 
             // Save credentials for token refresh
             try {
-                secureCredentialManager.savePassword(normalizedServerUrl, username, password)
+                secureCredentialManager.savePassword(serverUrl, username, password)
                 Log.d(TAG, "authenticateUser: Saved credentials for user '$username'")
             } catch (e: Exception) {
                 Log.w(TAG, "Failed to save credentials for token refresh", e)
@@ -173,10 +173,9 @@ class JellyfinAuthRepository @Inject constructor(
         val server = _currentServer.value ?: return false
         val username = server.username ?: return false
         val serverUrl = server.url
-        val normalizedServerUrl = server.normalizedUrl ?: normalizeServerUrl(serverUrl)
 
         try {
-            val password = secureCredentialManager.getPassword(normalizedServerUrl, username)
+            val password = secureCredentialManager.getPassword(serverUrl, username)
             if (password == null) {
                 Log.w(TAG, "reAuthenticate: No saved password found for user $username")
                 return false
@@ -215,8 +214,7 @@ class JellyfinAuthRepository @Inject constructor(
             val server = _currentServer.value
             if (server != null && server.username != null) {
                 try {
-                    val normalizedServerUrl = server.normalizedUrl ?: normalizeServerUrl(server.url)
-                    secureCredentialManager.clearPassword(normalizedServerUrl, server.username)
+                    secureCredentialManager.clearPassword(server.url, server.username)
                     Log.d(TAG, "logout: Cleared saved credentials for user ${server.username}")
                 } catch (e: Exception) {
                     Log.w(TAG, "logout: Failed to clear credentials", e)

--- a/app/src/main/java/com/rpeters/jellyfin/utils/ServerUrlNormalizer.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/utils/ServerUrlNormalizer.kt
@@ -15,11 +15,10 @@ fun normalizeServerUrl(input: String): String {
     return try {
         val uri = URI(url)
         val scheme = (uri.scheme ?: "https").lowercase()
-        val host = uri.host?.lowercase() ?: ""
-        val port = if (uri.port != -1) ":${uri.port}" else ""
+        val host = uri.host?.lowercase() ?: return input
         val path = uri.rawPath?.trimEnd('/') ?: ""
         buildString {
-            append(scheme).append("://").append(host).append(port)
+            append(scheme).append("://").append(host)
             if (path.isNotEmpty()) append(path)
         }
     } catch (_: URISyntaxException) {

--- a/app/src/test/java/com/rpeters/jellyfin/data/SecureCredentialManagerTest.kt
+++ b/app/src/test/java/com/rpeters/jellyfin/data/SecureCredentialManagerTest.kt
@@ -13,7 +13,7 @@ class SecureCredentialManagerTest {
 
     @Test
     fun `generateKey normalizes server URL`() {
-        val keyA = manager.generateKey("HTTPS://Example.com/", "user")
+        val keyA = manager.generateKey("HTTPS://Example.com:8920/", "user")
         val keyB = manager.generateKey("https://example.com", "user")
         assertEquals(keyA, keyB)
     }
@@ -24,18 +24,24 @@ class SecureCredentialManagerTest {
         val username = "user"
         val password = "secret"
 
-        val variantWithSlash = "https://Example.com/"
-        val variantUpper = "HTTPS://example.COM"
+        val variantWithPort = "https://Example.com:8096/"
+        val variantCanonical = "https://example.com"
 
-        store[manager.generateKey(variantWithSlash, username)] = password
+        store[manager.generateKey(variantWithPort, username)] = password
 
-        val retrieved = store[manager.generateKey(variantUpper, username)]
+        val retrieved = store[manager.generateKey(variantCanonical, username)]
         assertEquals(password, retrieved)
     }
 
     @Test
     fun `normalizeServerUrl trims and lowercases`() {
         val normalized = normalizeServerUrl(" HTTPS://Example.com/ ")
+        assertEquals("https://example.com", normalized)
+    }
+
+    @Test
+    fun `normalizeServerUrl removes port`() {
+        val normalized = normalizeServerUrl("https://example.com:8096/")
         assertEquals("https://example.com", normalized)
     }
 }


### PR DESCRIPTION
This pull request refactors how server URLs are normalized and used for credential management, ensuring consistent key generation and secure storage. The main improvements include internalizing URL normalization within credential operations, handling legacy key migration, and updating tests to reflect the new normalization logic. These changes help prevent duplicate credential entries and improve compatibility with legacy data.

**Credential Management Refactor:**

* The `SecureCredentialManager` now normalizes server URLs internally when generating keys, simplifying the interface for saving, retrieving, and clearing passwords. Legacy keys are handled and migrated automatically if needed. (`app/src/main/java/com/rpeters/jellyfin/data/SecureCredentialManager.kt`) [[1]](diffhunk://#diff-d4e663e2e4b0a057edf1bcb5415d16ebd22d4effec1c7f90b1089958aa4effacL166-R175) [[2]](diffhunk://#diff-d4e663e2e4b0a057edf1bcb5415d16ebd22d4effec1c7f90b1089958aa4effacL208-R214) [[3]](diffhunk://#diff-d4e663e2e4b0a057edf1bcb5415d16ebd22d4effec1c7f90b1089958aa4effacL239-R236) [[4]](diffhunk://#diff-d4e663e2e4b0a057edf1bcb5415d16ebd22d4effec1c7f90b1089958aa4effacR250-R270)

* The `JellyfinAuthRepository` no longer passes normalized URLs to credential operations; it uses raw server URLs, relying on the manager to handle normalization and migration. (`app/src/main/java/com/rpeters/jellyfin/data/repository/JellyfinAuthRepository.kt`) [[1]](diffhunk://#diff-f7c22a285d8280ddadee31f07449992a94b83885457a716d35b04fc7dd67ea62L132-R132) [[2]](diffhunk://#diff-f7c22a285d8280ddadee31f07449992a94b83885457a716d35b04fc7dd67ea62L176-R178) [[3]](diffhunk://#diff-f7c22a285d8280ddadee31f07449992a94b83885457a716d35b04fc7dd67ea62L218-R217)

**URL Normalization Improvements:**

* The normalization function now strips ports and enforces lowercase for scheme and host, ensuring that keys are generated consistently regardless of input format. (`app/src/main/java/com/rpeters/jellyfin/utils/ServerUrlNormalizer.kt`, `URL_NORMALIZATION_FIX.md`) [[1]](diffhunk://#diff-db86285801528be38c5bbd7279592a92880d203103467fdb2fc80c1ffe069cadL18-R21) [[2]](diffhunk://#diff-8937ff50b7e95bbbc7cc2ddbdbf77f9b9665dbe38db0c55f54b2b253bf94c9eaL21-R44)

**Testing Updates:**

* Unit tests for credential key generation and URL normalization have been updated to verify that ports are removed and canonical forms are used, preventing mismatches. (`app/src/test/java/com/rpeters/jellyfin/data/SecureCredentialManagerTest.kt`) [[1]](diffhunk://#diff-c5906343ef70afddcd212f87d2bee49039a3af6d2f5391514cf997133fa131b3L16-R16) [[2]](diffhunk://#diff-c5906343ef70afddcd212f87d2bee49039a3af6d2f5391514cf997133fa131b3L27-R32) [[3]](diffhunk://#diff-c5906343ef70afddcd212f87d2bee49039a3af6d2f5391514cf997133fa131b3R41-R46)## Summary

- What does this PR change and why?
- Link related issues (e.g., Closes #123)

## Type of change

- [ ] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no functional change)
- [ ] perf (performance improvement)
- [ ] test (add/fix tests)
- [ ] chore (build, tooling, deps)

## Screenshots/GIFs (UI changes)

<!-- If UI changed, add before/after screenshots or a short GIF. -->

## How to test

```bash
# Build
./gradlew assembleDebug

# Unit tests
./gradlew testDebugUnitTest

# Lint
./gradlew lintDebug

# Coverage (HTML under app/build/reports)
./gradlew jacocoTestReport
```

## Checklist

- [ ] Follows Conventional Commits
- [ ] Branch named appropriately (feature/..., bugfix/..., hotfix/..., docs/...)
- [ ] Tests added/updated where applicable
- [ ] `./gradlew testDebugUnitTest` passes
- [ ] `./gradlew lintDebug` passes
- [ ] Docs updated (README/CHANGELOG as needed)
- [ ] Affected areas and testing notes included



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved server URL handling: defaults to https when scheme is missing, trims input, lowercases scheme/host, removes ports, and preserves valid paths.
- Bug Fixes
  - Credentials now work consistently across URL variants (with/without port, different casing), reducing duplicate entries and login issues.
  - Safer normalization returns the original input on errors and avoids empty-host cases.
- Documentation
  - Updated guidance on credential storage/lookup and internal URL normalization behavior.
- Tests
  - Added/updated tests for port-insensitive keys and URL normalization (including port removal).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->