### PR TITLE
fix: migrate legacy credential keys

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/utils/ServerUrlNormalizer.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/utils/ServerUrlNormalizer.kt
@@ -25,3 +25,27 @@ fun normalizeServerUrl(input: String): String {
         url
     }
 }
+
+/**
+ * Legacy URL normalization that preserves the port number.
+ * Used for migrating credentials saved with the previous logic.
+ */
+fun normalizeServerUrlLegacy(input: String): String {
+    var url = input.trim()
+    if (!url.startsWith("http://", ignoreCase = true) && !url.startsWith("https://", ignoreCase = true)) {
+        url = "https://$url"
+    }
+    return try {
+        val uri = URI(url)
+        val scheme = (uri.scheme ?: "https").lowercase()
+        val host = uri.host?.lowercase() ?: return url
+        val port = if (uri.port != -1) ":${uri.port}" else ""
+        val path = uri.rawPath?.trimEnd('/') ?: ""
+        buildString {
+            append(scheme).append("://").append(host).append(port)
+            if (path.isNotEmpty()) append(path)
+        }
+    } catch (_: URISyntaxException) {
+        url
+    }
+}

--- a/app/src/test/java/com/rpeters/jellyfin/data/SecureCredentialManagerTest.kt
+++ b/app/src/test/java/com/rpeters/jellyfin/data/SecureCredentialManagerTest.kt
@@ -2,6 +2,7 @@ package com.rpeters.jellyfin.data
 
 import android.content.Context
 import com.rpeters.jellyfin.utils.normalizeServerUrl
+import com.rpeters.jellyfin.utils.normalizeServerUrlLegacy
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -12,9 +13,9 @@ class SecureCredentialManagerTest {
     private val manager = SecureCredentialManager(context)
 
     @Test
-    fun `generateKey normalizes server URL`() {
-        val keyA = manager.generateKey("HTTPS://Example.com:8920/", "user")
-        val keyB = manager.generateKey("https://example.com", "user")
+    fun `generateKey produces consistent key for normalized URLs`() {
+        val keyA = manager.generateKey(normalizeServerUrl("HTTPS://Example.com:8920/"), "user")
+        val keyB = manager.generateKey(normalizeServerUrl("https://example.com"), "user")
         assertEquals(keyA, keyB)
     }
 
@@ -27,9 +28,9 @@ class SecureCredentialManagerTest {
         val variantWithPort = "https://Example.com:8096/"
         val variantCanonical = "https://example.com"
 
-        store[manager.generateKey(variantWithPort, username)] = password
+        store[manager.generateKey(normalizeServerUrlLegacy(variantWithPort), username)] = password
 
-        val retrieved = store[manager.generateKey(variantCanonical, username)]
+        val retrieved = store[manager.generateKey(normalizeServerUrl(variantCanonical), username)]
         assertEquals(password, retrieved)
     }
 
@@ -43,5 +44,11 @@ class SecureCredentialManagerTest {
     fun `normalizeServerUrl removes port`() {
         val normalized = normalizeServerUrl("https://example.com:8096/")
         assertEquals("https://example.com", normalized)
+    }
+
+    @Test
+    fun `normalizeServerUrlLegacy retains port`() {
+        val normalized = normalizeServerUrlLegacy(" HTTPS://Example.com:8096/ ")
+        assertEquals("https://example.com:8096", normalized)
     }
 }


### PR DESCRIPTION
This pull request refactors the handling and migration of server credential keys in the `SecureCredentialManager` to better support legacy formats and ensure consistency. It introduces a new legacy normalization function, updates how credential keys are generated and migrated, and improves test coverage for these changes.

**Credential Key Management and Migration:**

* Updated `CredentialKeys` to track three keys: `newKey`, `legacyRawKey`, and `legacyNormalizedKey`, enabling more robust migration and cleanup of old credentials.
* Refactored credential migration logic to search for both legacy key formats and migrate them individually to the new key, ensuring no credentials are lost during upgrade.
* Revised credential removal and update logic to clean up all legacy key variants, not just a single legacy key. [[1]](diffhunk://#diff-d4e663e2e4b0a057edf1bcb5415d16ebd22d4effec1c7f90b1089958aa4effacL172-R176) [[2]](diffhunk://#diff-d4e663e2e4b0a057edf1bcb5415d16ebd22d4effec1c7f90b1089958aa4effacL233-R245)

**Legacy URL Normalization Support:**

* Added `normalizeServerUrlLegacy` in `ServerUrlNormalizer.kt` to preserve port numbers for legacy credential migration, ensuring compatibility with previously saved credentials.
* Updated key generation to use both modern and legacy normalization functions, so credentials saved with either scheme can be found and migrated.

**Testing Improvements:**

* Enhanced unit tests to cover legacy normalization, key generation consistency, and credential retrieval using both normalization schemes. [[1]](diffhunk://#diff-c5906343ef70afddcd212f87d2bee49039a3af6d2f5391514cf997133fa131b3L15-R18) [[2]](diffhunk://#diff-c5906343ef70afddcd212f87d2bee49039a3af6d2f5391514cf997133fa131b3L30-R33) [[3]](diffhunk://#diff-c5906343ef70afddcd212f87d2bee49039a3af6d2f5391514cf997133fa131b3R48-R53)
* Added tests specifically for the legacy normalization function to ensure it retains port information as expected.## Summary

- What does this PR change and why?
- Link related issues (e.g., Closes #123)

## Type of change

- [ ] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no functional change)
- [ ] perf (performance improvement)
- [ ] test (add/fix tests)
- [ ] chore (build, tooling, deps)

## Screenshots/GIFs (UI changes)

<!-- If UI changed, add before/after screenshots or a short GIF. -->

## How to test

```bash
# Build
./gradlew assembleDebug

# Unit tests
./gradlew testDebugUnitTest

# Lint
./gradlew lintDebug

# Coverage (HTML under app/build/reports)
./gradlew jacocoTestReport
```

## Checklist

- [ ] Follows Conventional Commits
- [ ] Branch named appropriately (feature/..., bugfix/..., hotfix/..., docs/...)
- [ ] Tests added/updated where applicable
- [ ] `./gradlew testDebugUnitTest` passes
- [ ] `./gradlew lintDebug` passes
- [ ] Docs updated (README/CHANGELOG as needed)
- [ ] Affected areas and testing notes included



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved reliability of saved sign-ins by correctly handling server URLs with or without ports.
  - Automatically finds and migrates existing credentials saved under older URL formats.
  - Cleans up outdated credential entries to prevent duplicates or stale data.

- New Features
  - Legacy URL normalization that preserves port numbers for better compatibility with previously saved servers.

- Tests
  - Added tests to ensure legacy URL normalization preserves ports.
  - Updated credential storage/retrieval tests to validate consistent behavior across URL variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->