### PR TITLE
feat: show recently added TV shows on home screen

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/HomeScreen.kt
@@ -339,6 +339,27 @@ fun HomeContent(
                 }
             }
 
+            if (recentTVShows.isNotEmpty()) {
+                item(key = "recent_tvshows", contentType = "carousel") {
+                    val items = remember(recentTVShows) {
+                        recentTVShows.take(15).map {
+                            it.toCarouselItem(
+                                titleOverride = it.name ?: "Unknown",
+                                subtitleOverride = itemSubtitle(it),
+                                imageUrl = getImageUrl(it) ?: "",
+                            )
+                        }
+                    }
+                    ExpressiveMediaCarousel(
+                        title = "Recently Added TV Shows",
+                        items = items,
+                        onItemClick = { selected ->
+                            recentTVShows.firstOrNull { it.id?.toString() == selected.id }?.let(onItemClick)
+                        },
+                    )
+                }
+            }
+
             if (recentEpisodes.isNotEmpty()) {
                 item(key = "recent_episodes", contentType = "carousel") {
                     val items = remember(recentEpisodes) {


### PR DESCRIPTION
## Summary
- show Recently Added TV Shows carousel on HomeScreen
- allow opening a selected series from that carousel

## Testing
- `./gradlew testDebugUnitTest` *(fails: SDK location not found)*
- `./gradlew lintDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b72d4bc5c4832782b03c784e7ce6ed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Recently Added TV Shows” carousel on the Home screen, appearing after “Recently Added Movies.”
  * Displays up to 8 of the latest series with titles, subtitles, and artwork (with fallback).
  * Supports tapping items to open their details.
  * Improves home browsing by highlighting newly added TV content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->