### PR TITLE
docs: mark TV loading/error states as implemented

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -43,7 +43,7 @@ These are focused, near-term items discovered during code review to solidify aut
   - [x] TvContentCarousel with auto-scroll for focused item
   - [x] TvLibraryCard section for libraries
   - [x] Basic TvItemDetailScreen (poster, backdrop, overview, Play/Resume)
-  - [ ] TV loading/error states (skeleton, banners)
+  - [x] TV loading/error states (skeleton, banners)
 
 - [~] **Focus Management System**
   - [x] Initial focus set on first carousel and libraries row


### PR DESCRIPTION
## Summary
- mark TV loading/error states roadmap item complete

## Testing
- `./gradlew testDebugUnitTest` *(fails: SDK location not found)*
- `./gradlew lintDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b76f56a8a48327aee1acf1c572219a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the project roadmap to mark “TV loading/error states (skeleton, banners)” as completed under the TV UI Components Library.
  * Clarifies current progress and improves transparency for stakeholders and contributors.
  * No changes to app functionality, UI, or performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->