### PR TITLE
docs: mark focus manager util as implemented

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -48,7 +48,7 @@ These are focused, near-term items discovered during code review to solidify aut
 - [~] **Focus Management System**
   - [x] Initial focus set on first carousel and libraries row
   - [x] Simple focus glow/elevation on cards
-  - [x] Central FocusManager util implemented via `TvFocusManager` (save/restore focus per row/screen)
+  - [x] Central FocusManager util implemented via [`TvFocusManager`](app/src/main/java/com/rpeters/jellyfin/ui/tv/TvFocusManager.kt) (save/restore focus per row/screen)
   - [ ] TV remote shortcuts; keyboard navigation parity
 
 - [ ] **Adaptive Layout System**


### PR DESCRIPTION
## Summary
- mark Central FocusManager util as completed in roadmap
- reference the `TvFocusManager` implementation

## Testing
- `./gradlew testDebugUnitTest lintDebug` *(fails: SDK location not found)*
- `./gradlew lintDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b76f59607c8327802c349ce80153ff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Roadmap updated: Focus Management System marked as implemented, indicating centralized focus save/restore across rows/screens is available.
  - Confirms no functional changes to the product or public APIs; other roadmap items unchanged.
  - Improves transparency and planning accuracy for users evaluating adoption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->