### PR TITLE
Fix(MediaLibraryViewModel): Fix library items not showing

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/ui/viewmodel/MediaLibraryViewModel.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/viewmodel/MediaLibraryViewModel.kt
@@ -155,7 +155,7 @@ class MediaLibraryViewModel @Inject constructor(
                 } else {
                     _libraryState.value = _libraryState.value.copy(
                         isLoadingMovies = false,
-                        errorMessage = (result as? ApiResult.Error)?.message ?: "Failed to load libraries"
+                        errorMessage = (result as? ApiResult.Error)?.message ?: "Failed to load libraries",
                     )
                     return@launch
                 }
@@ -256,7 +256,7 @@ class MediaLibraryViewModel @Inject constructor(
                 } else {
                     _libraryState.value = _libraryState.value.copy(
                         isLoadingTVShows = false,
-                        errorMessage = (result as? ApiResult.Error)?.message ?: "Failed to load libraries"
+                        errorMessage = (result as? ApiResult.Error)?.message ?: "Failed to load libraries",
                     )
                     return@launch
                 }
@@ -349,7 +349,7 @@ class MediaLibraryViewModel @Inject constructor(
                     result.data
                 } else {
                     _libraryState.value = _libraryState.value.copy(
-                        errorMessage = (result as? ApiResult.Error)?.message ?: "Failed to load libraries"
+                        errorMessage = (result as? ApiResult.Error)?.message ?: "Failed to load libraries",
                     )
                     return@launch
                 }


### PR DESCRIPTION
This pull request refactors how the `MediaLibraryViewModel` loads media library content, addressing race conditions and ensuring all relevant libraries are processed for each content type. The main improvements include awaiting library data before loading items, fetching from all applicable libraries rather than just the first, and updating error handling and state management for more robust and accurate results.

**Race condition and library loading fixes:**

* Changed logic to await the result of `getUserLibraries` before proceeding to load movies, TV shows, music, or other content, preventing race conditions where content loading could start before libraries are available. [[1]](diffhunk://#diff-f88c9f43da31be4a5143a78ed15e5cab4cc64a27146c2208fff7e08b813893cfL148-R171) [[2]](diffhunk://#diff-f88c9f43da31be4a5143a78ed15e5cab4cc64a27146c2208fff7e08b813893cfL243-R272) [[3]](diffhunk://#diff-f88c9f43da31be4a5143a78ed15e5cab4cc64a27146c2208fff7e08b813893cfL330-L348)

**Multi-library support for content loading:**

* Updated movies and TV shows loading to fetch items from all matching libraries, not just the first, aggregating results and handling pagination and errors across multiple libraries. [[1]](diffhunk://#diff-f88c9f43da31be4a5143a78ed15e5cab4cc64a27146c2208fff7e08b813893cfL173-R223) [[2]](diffhunk://#diff-f88c9f43da31be4a5143a78ed15e5cab4cc64a27146c2208fff7e08b813893cfL267-R324)
* Refactored music and "other" content loading to process all relevant libraries, not just the first one, ensuring complete coverage of available content.

**Error handling and state updates:**

* Improved error reporting and state updates to reflect errors from any library fetch, and to accurately represent loading states and available content. [[1]](diffhunk://#diff-f88c9f43da31be4a5143a78ed15e5cab4cc64a27146c2208fff7e08b813893cfL148-R171) [[2]](diffhunk://#diff-f88c9f43da31be4a5143a78ed15e5cab4cc64a27146c2208fff7e08b813893cfL173-R223) [[3]](diffhunk://#diff-f88c9f43da31be4a5143a78ed15e5cab4cc64a27146c2208fff7e08b813893cfL243-R272) [[4]](diffhunk://#diff-f88c9f43da31be4a5143a78ed15e5cab4cc64a27146c2208fff7e08b813893cfL267-R324) [[5]](diffhunk://#diff-f88c9f43da31be4a5143a78ed15e5cab4cc64a27146c2208fff7e08b813893cfL330-L348)

**API and method signature changes:**

* Changed `loadMusicContent` and `loadOtherContent` to take a list of libraries as a parameter and made them `suspend` functions to support asynchronous operation and multi-library processing. [[1]](diffhunk://#diff-f88c9f43da31be4a5143a78ed15e5cab4cc64a27146c2208fff7e08b813893cfL363-R409) [[2]](diffhunk://#diff-f88c9f43da31be4a5143a78ed15e5cab4cc64a27146c2208fff7e08b813893cfL330-L348)

**Logging improvements:**

* Enhanced debug logging to report the number of items loaded and the number of libraries processed for movies and TV shows, aiding diagnostics and transparency. [[1]](diffhunk://#diff-f88c9f43da31be4a5143a78ed15e5cab4cc64a27146c2208fff7e08b813893cfL173-R223) [[2]](diffhunk://#diff-f88c9f43da31be4a5143a78ed15e5cab4cc64a27146c2208fff7e08b813893cfL267-R324)

Let me know if you want to go over any part of the refactored logic in more detail!This commit fixes two critical issues in the MediaLibraryViewModel that prevented library items from being displayed correctly:

1.  **Race Condition:** The content loading functions (e.g., `loadMovies`, `loadTVShows`) were attempting to fetch media items before the list of user libraries was loaded. This was due to an asynchronous call to `loadLibraries` without awaiting the result. The logic has been restructured to ensure the library list is available before proceeding, fixing the empty screen issue.

2.  **Single Library Flaw:** The code was only fetching items from the *first* discovered library of a given type (e.g., movies, TV shows). This has been corrected to iterate over all libraries of the correct type and aggregate the items, ensuring that all content is displayed for users with multiple libraries.

## Summary

- What does this PR change and why?
- Link related issues (e.g., Closes #123)

## Type of change

- [ ] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no functional change)
- [ ] perf (performance improvement)
- [ ] test (add/fix tests)
- [ ] chore (build, tooling, deps)

## Screenshots/GIFs (UI changes)

<!-- If UI changed, add before/after screenshots or a short GIF. -->

## How to test

```bash
# Build
./gradlew assembleDebug

# Unit tests
./gradlew testDebugUnitTest

# Lint
./gradlew lintDebug

# Coverage (HTML under app/build/reports)
./gradlew jacocoTestReport
```

## Checklist

- [ ] Follows Conventional Commits
- [ ] Branch named appropriately (feature/..., bugfix/..., hotfix/..., docs/...)
- [ ] Tests added/updated where applicable
- [ ] `./gradlew testDebugUnitTest` passes
- [ ] `./gradlew lintDebug` passes
- [ ] Docs updated (README/CHANGELOG as needed)
- [ ] Affected areas and testing notes included



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Movies, TV shows, music, and other content now aggregate from all relevant libraries, not just one.
  - Content loaders handle multiple libraries in a single view for broader coverage.

- Bug Fixes
  - Resolved a race condition by ensuring libraries fully load before fetching content.
  - Improved reliability of pagination (has more items) across libraries.
  - Enhanced error handling with clearer status updates when some libraries fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->