### PR TITLE
fix: guard music data load in MusicScreen

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/MusicScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/MusicScreen.kt
@@ -142,9 +142,12 @@ fun MusicScreen(
         Log.d("MusicScreen-Debug", "  getLibraryTypeData(MUSIC): ${musicData.size} items")
     }
 
-    // Trigger load when libraries are available
+    // Trigger load only if music data hasn't been loaded yet
     LaunchedEffect(appState.libraries) {
-        if (appState.libraries.isNotEmpty()) {
+        if (
+            appState.libraries.isNotEmpty() &&
+            viewModel.getLibraryTypeData(LibraryType.MUSIC).isEmpty()
+        ) {
             viewModel.loadLibraryTypeData(LibraryType.MUSIC, forceRefresh = false)
         }
     }


### PR DESCRIPTION
## Summary
- prevent MusicScreen from triggering duplicate music data loads
- allow NavGraph to remain sole source for initial music data fetching

## Testing
- `./gradlew testDebugUnitTest lintDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e4dcafe88327b09d29e80aba8247

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents redundant loading of music content on the Music screen. Data now loads only when libraries are available and music hasn’t been fetched yet, reducing duplicate network calls and UI churn. Users should experience faster readiness, less flicker during navigation/resume, and improved data/battery efficiency, especially on poor connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->