### PR TITLE
refactor: remove redundant TV show load

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/TVShowsScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/TVShowsScreen.kt
@@ -134,12 +134,7 @@ fun TVShowsScreen(
     var viewMode by remember { mutableStateOf(TVShowViewMode.GRID) }
     var showSortMenu by remember { mutableStateOf(false) }
 
-    // Trigger load when libraries are available (prevents early no-op)
-    LaunchedEffect(appState.libraries) {
-        if (appState.libraries.isNotEmpty()) {
-            viewModel.loadLibraryTypeData(LibraryType.TV_SHOWS, forceRefresh = false)
-        }
-    }
+    // TV show data is loaded via NavGraph effect
 
     // Get items provided by the unified library loader (Series only)
     val tvShowItems = remember(appState.itemsByLibrary, appState.libraries) {


### PR DESCRIPTION
## Summary
- remove now-unnecessary LaunchedEffect in TV shows screen so NavGraph handles loading

## Testing
- `./gradlew testDebugUnitTest` *(fails: SDK location not found)*
- `./gradlew lintDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e4ddffe08327b4dfb75d506d05e1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined TV Shows screen data loading by delegating it to the navigation flow, reducing screen-level side effects.
  * Improves consistency of when TV show data is fetched during navigation.
  * No changes to filtering, sorting, or visual presentation.
  * No user-facing behavior changes expected; this prepares for more reliable data handling across screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->