### PR TITLE
feat: show loading state for movie and TV libraries

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/MoviesScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/MoviesScreen.kt
@@ -227,8 +227,8 @@ fun MoviesScreen(
     ) { paddingValues ->
         // Determine current screen state
         val currentState = when {
-            isLoading && movies.isEmpty() -> MovieScreenState.LOADING
-            movies.isEmpty() && !isLoading -> MovieScreenState.EMPTY
+            isLoading -> MovieScreenState.LOADING
+            movies.isEmpty() -> MovieScreenState.EMPTY
             else -> MovieScreenState.CONTENT
         }
 

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/TVShowsScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/TVShowsScreen.kt
@@ -330,7 +330,7 @@ fun TVShowsScreen(
             // Content with Expressive animations
             AnimatedContent(
                 targetState = when {
-                    appState.isLoadingTVShows && tvShowItems.isEmpty() -> TVShowContentState.LOADING
+                    appState.isLoadingTVShows -> TVShowContentState.LOADING
                     appState.errorMessage != null -> TVShowContentState.ERROR
                     filteredAndSortedTVShows.isEmpty() -> TVShowContentState.EMPTY
                     else -> TVShowContentState.CONTENT

--- a/app/src/main/java/com/rpeters/jellyfin/ui/viewmodel/MainAppViewModel.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/viewmodel/MainAppViewModel.kt
@@ -148,7 +148,10 @@ class MainAppViewModel @Inject constructor(
             android.util.Log.d("MainAppViewModel-Initial", "🚀 Starting loadInitialData (forceRefresh=$forceRefresh)")
             android.util.Log.d("MainAppViewModel-Initial", "  Current libraries count: ${_appState.value.libraries.size}")
 
-            _appState.value = _appState.value.copy(isLoading = true, errorMessage = null)
+            _appState.value = _appState.value.copy(
+                isLoading = true,
+                errorMessage = null,
+            )
 
             try {
                 coroutineScope {
@@ -375,7 +378,20 @@ class MainAppViewModel @Inject constructor(
             android.util.Log.d("MainAppViewModel-Load", "  ItemKinds: ${libraryType.itemKinds}")
             android.util.Log.d("MainAppViewModel-Load", "  ForceRefresh: $forceRefresh")
 
-            _appState.value = _appState.value.copy(isLoading = true, errorMessage = null)
+            _appState.value = _appState.value.copy(
+                isLoading = true,
+                errorMessage = null,
+                isLoadingMovies = if (libraryType == LibraryType.MOVIES) {
+                    true
+                } else {
+                    _appState.value.isLoadingMovies
+                },
+                isLoadingTVShows = if (libraryType == LibraryType.TV_SHOWS) {
+                    true
+                } else {
+                    _appState.value.isLoadingTVShows
+                },
+            )
 
             // Map BaseItemKind to Jellyfin API item type names
             fun mapKindsToApiNames(kinds: List<BaseItemKind>): String =
@@ -435,6 +451,16 @@ class MainAppViewModel @Inject constructor(
                     _appState.value = _appState.value.copy(
                         itemsByLibrary = updated,
                         isLoading = false,
+                        isLoadingMovies = if (libraryType == LibraryType.MOVIES) {
+                            false
+                        } else {
+                            _appState.value.isLoadingMovies
+                        },
+                        isLoadingTVShows = if (libraryType == LibraryType.TV_SHOWS) {
+                            false
+                        } else {
+                            _appState.value.isLoadingTVShows
+                        },
                     )
                     android.util.Log.d("MainAppViewModel-Load", "✅ State updated - itemsByLibrary now has ${updated.size} libraries")
                 }
@@ -443,6 +469,16 @@ class MainAppViewModel @Inject constructor(
                     _appState.value = _appState.value.copy(
                         isLoading = false,
                         errorMessage = "Failed to load library items: ${result.message}",
+                        isLoadingMovies = if (libraryType == LibraryType.MOVIES) {
+                            false
+                        } else {
+                            _appState.value.isLoadingMovies
+                        },
+                        isLoadingTVShows = if (libraryType == LibraryType.TV_SHOWS) {
+                            false
+                        } else {
+                            _appState.value.isLoadingTVShows
+                        },
                     )
                 }
                 is ApiResult.Loading -> {


### PR DESCRIPTION
## Summary
- track movie and TV library loading in `MainAppViewModel`
- surface movie loading state in `MoviesScreen`
- surface TV show loading state in `TVShowsScreen`

## Testing
- `./gradlew testDebugUnitTest` *(fails: SDK location not found)*
- `./gradlew lintDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e4decfc8832788ccea42651b479d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Independent loading indicators for Movies and TV Shows, providing more accurate status while each library loads.
  - Loading can appear during background refresh even when items are already visible, improving feedback.

- Bug Fixes
  - Empty state now appears immediately when no items are available, no longer waiting for loading to complete.
  - More consistent state transitions between Loading, Empty, and Content across Movies and TV Shows screens.

- UX Improvements
  - Smoother, clearer UI behavior during data fetches for each content type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->