### PR TITLE
fix: rely on navgraph for music load

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/MusicScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/MusicScreen.kt
@@ -142,16 +142,6 @@ fun MusicScreen(
         Log.d("MusicScreen-Debug", "  getLibraryTypeData(MUSIC): ${musicData.size} items")
     }
 
-    // Trigger load only if music data hasn't been loaded yet
-    LaunchedEffect(appState.libraries) {
-        if (
-            appState.libraries.isNotEmpty() &&
-            viewModel.getLibraryTypeData(LibraryType.MUSIC).isEmpty()
-        ) {
-            viewModel.loadLibraryTypeData(LibraryType.MUSIC, forceRefresh = false)
-        }
-    }
-
     // Get music items via unified loader and enrich with recent audio
     val musicItems = remember(appState.itemsByLibrary, appState.recentlyAddedByTypes, appState.libraries) {
         val libraryMusic = viewModel.getLibraryTypeData(LibraryType.MUSIC)


### PR DESCRIPTION
## Summary
- remove redundant LaunchedEffect from MusicScreen so music data is only loaded via NavGraph

## Testing
- `./gradlew testDebugUnitTest` *(fails: SDK location not found)*
- `./gradlew lintDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ecbe65548327a334bb4f1cac0767

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Updated Music screen loading behavior to stop auto-loading the music library in the background. Content now appears when triggered by other actions, reducing unintended network usage and improving initial responsiveness. Users may notice music sections populate after a manual refresh or relevant navigation. Display of items remains unchanged once data is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->