### PR TITLE
fix: offload app initialization to background

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/JellyfinApplication.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/JellyfinApplication.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @HiltAndroidApp
@@ -24,7 +25,7 @@ class JellyfinApplication : Application(), ImageLoaderFactory {
     @Inject
     lateinit var imageLoader: ImageLoader
 
-    private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+    private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
     companion object {
         private const val TAG = "JellyfinApplication"
@@ -64,27 +65,31 @@ class JellyfinApplication : Application(), ImageLoaderFactory {
                 // Configure StrictMode with network optimizations
                 NetworkOptimizer.configureNetworkStrictMode()
 
-                SecureLogger.i(TAG, "Performance optimizations initialized")
+                withContext(Dispatchers.Main) {
+                    SecureLogger.i(TAG, "Performance optimizations initialized")
+                }
             } catch (e: Exception) {
-                SecureLogger.e(TAG, "Failed to initialize performance optimizations", e)
+                withContext(Dispatchers.Main) {
+                    SecureLogger.e(TAG, "Failed to initialize performance optimizations", e)
 
-                // Fallback to basic StrictMode if optimizations fail
-                if (BuildConfig.DEBUG) {
-                    StrictMode.setThreadPolicy(
-                        StrictMode.ThreadPolicy.Builder()
-                            .detectDiskReads()
-                            .detectDiskWrites()
-                            .detectNetwork()
-                            .penaltyLog()
-                            .build(),
-                    )
-                    StrictMode.setVmPolicy(
-                        StrictMode.VmPolicy.Builder()
-                            .detectLeakedClosableObjects()
-                            .detectUntaggedSockets()
-                            .penaltyLog()
-                            .build(),
-                    )
+                    // Fallback to basic StrictMode if optimizations fail
+                    if (BuildConfig.DEBUG) {
+                        StrictMode.setThreadPolicy(
+                            StrictMode.ThreadPolicy.Builder()
+                                .detectDiskReads()
+                                .detectDiskWrites()
+                                .detectNetwork()
+                                .penaltyLog()
+                                .build(),
+                        )
+                        StrictMode.setVmPolicy(
+                            StrictMode.VmPolicy.Builder()
+                                .detectLeakedClosableObjects()
+                                .detectUntaggedSockets()
+                                .penaltyLog()
+                                .build(),
+                        )
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- move applicationScope to Dispatchers.Default for background initialization
- switch performance optimizations fallback to Dispatchers.Main for UI operations

## Testing
- `./gradlew testDebugUnitTest` *(fails: SDK location not found)*
- `./gradlew lintDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf240314488327b3c4c8a225f75504

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app startup stability by ensuring certain initialization steps run on the appropriate thread, reducing potential race conditions or UI hiccups.
* **Refactor**
  * Adjusted internal initialization threading to enhance responsiveness without changing user-facing functionality.
* **Chores**
  * Streamlined logging behavior during startup for clearer, more reliable diagnostics in development builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->