### PR TITLE
refactor: precompute home screen lists in view model

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/HomeScreen.kt
@@ -37,9 +37,9 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale

--- a/app/src/main/java/com/rpeters/jellyfin/ui/viewmodel/MainAppViewModel.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/viewmodel/MainAppViewModel.kt
@@ -26,8 +26,8 @@ import kotlinx.coroutines.withContext
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemKind
 import org.jellyfin.sdk.model.api.CollectionType
-import java.util.UUID
 import java.util.Locale
+import java.util.UUID
 import javax.inject.Inject
 
 /**


### PR DESCRIPTION
## Summary
- precompute continue-watching and library ordering in MainAppViewModel on `Dispatchers.IO`
- expose `continueWatching` and `sortedLibraries` via `MainAppState`
- update `HomeContent` to read state directly and use `derivedStateOf` for minor derivations

## Testing
- `./gradlew testDebugUnitTest` *(fails: SDK location not found)*
- `./gradlew lintDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf2404eafc832795b8e6fc722d6d1d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Home Videos” section showing recent videos.
  * Updated Featured carousel to highlight recent movies and TV shows together.

* **Improvements**
  * Faster, smoother Home screen with fewer unnecessary refreshes.
  * Continue Watching list is more accurate and better ordered.
  * Libraries are consistently sorted by type for easier browsing.
  * Recently Added sections are streamlined with clearer, capped lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->