### PR TITLE
feat: cache device type lookups

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/MainActivity.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.rpeters.jellyfin
 
+import android.content.res.Configuration
 import android.os.Bundle
 import android.util.Log
 import androidx.activity.ComponentActivity
@@ -39,5 +40,10 @@ class MainActivity : ComponentActivity() {
     override fun onDestroy() {
         super.onDestroy()
         MainThreadMonitor.stopMonitoring()
+    }
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        DeviceTypeUtils.invalidateCache()
     }
 }


### PR DESCRIPTION
## Summary
- cache computed device type in `DeviceTypeUtils` and allow clearing when configuration changes
- hook `MainActivity` into configuration change callbacks to reset the cache

## Testing
- `./gradlew testDebugUnitTest` *(fails: SDK location not found)*
- `./gradlew lintDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf2405f87c8327a1b7c7195fc3360e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrects device-type detection after configuration changes (e.g., orientation, input mode), ensuring the app consistently selects the right UI for TV, tablet, or mobile.

- Performance
  - Adds caching for device-type detection to reduce repeated computations and improve startup and navigation responsiveness.

- Stability
  - Improves reliability of UI mode switching by clearing outdated device-type info when system settings change, reducing misclassification-related glitches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->