### PR TITLE
Inject time provider into JellyfinAuthRepository

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/data/repository/JellyfinAuthRepository.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/data/repository/JellyfinAuthRepository.kt
@@ -1,6 +1,7 @@
 package com.rpeters.jellyfin.data.repository
 
 import android.util.Log
+import androidx.annotation.VisibleForTesting
 import com.rpeters.jellyfin.data.JellyfinServer
 import com.rpeters.jellyfin.data.SecureCredentialManager
 import com.rpeters.jellyfin.data.model.QuickConnectResult
@@ -10,7 +11,6 @@ import com.rpeters.jellyfin.data.repository.common.ApiResult
 import com.rpeters.jellyfin.data.repository.common.ErrorType
 import com.rpeters.jellyfin.data.utils.RepositoryUtils
 import com.rpeters.jellyfin.utils.normalizeServerUrl
-import androidx.annotation.VisibleForTesting
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow

--- a/app/src/main/java/com/rpeters/jellyfin/data/repository/JellyfinAuthRepository.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/data/repository/JellyfinAuthRepository.kt
@@ -10,6 +10,7 @@ import com.rpeters.jellyfin.data.repository.common.ApiResult
 import com.rpeters.jellyfin.data.repository.common.ErrorType
 import com.rpeters.jellyfin.data.utils.RepositoryUtils
 import com.rpeters.jellyfin.utils.normalizeServerUrl
+import androidx.annotation.VisibleForTesting
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -28,6 +29,7 @@ import javax.inject.Singleton
 class JellyfinAuthRepository @Inject constructor(
     private val jellyfin: Jellyfin,
     private val secureCredentialManager: SecureCredentialManager,
+    private val timeProvider: () -> Long = System::currentTimeMillis,
 ) : TokenProvider {
     private val authMutex = Mutex()
 
@@ -117,7 +119,7 @@ class JellyfinAuthRepository @Inject constructor(
                 userId = authResult.user?.id?.toString(),
                 username = username,
                 accessToken = authResult.accessToken,
-                loginTimestamp = System.currentTimeMillis(),
+                loginTimestamp = timeProvider(),
                 normalizedUrl = normalizedServerUrl,
             )
 
@@ -204,9 +206,15 @@ class JellyfinAuthRepository @Inject constructor(
     fun isTokenExpired(): Boolean {
         val server = _currentServer.value ?: return true
         val loginTimestamp = server.loginTimestamp ?: return true
-        val currentTime = System.currentTimeMillis()
+        val currentTime = timeProvider()
 
         return (currentTime - loginTimestamp) > TOKEN_VALIDITY_DURATION_MS
+    }
+
+    @VisibleForTesting
+    fun seedCurrentServer(server: JellyfinServer?) {
+        _currentServer.value = server
+        _isConnected.value = server?.isConnected == true
     }
 
     suspend fun logout() {

--- a/app/src/test/java/com/rpeters/jellyfin/data/repository/JellyfinAuthRepositoryTest.kt
+++ b/app/src/test/java/com/rpeters/jellyfin/data/repository/JellyfinAuthRepositoryTest.kt
@@ -10,7 +10,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
-import java.util.UUID
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -30,6 +29,7 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import java.util.UUID
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class JellyfinAuthRepositoryTest {

--- a/app/src/test/java/com/rpeters/jellyfin/data/repository/JellyfinAuthRepositoryTest.kt
+++ b/app/src/test/java/com/rpeters/jellyfin/data/repository/JellyfinAuthRepositoryTest.kt
@@ -1,92 +1,190 @@
 package com.rpeters.jellyfin.data.repository
 
+import com.rpeters.jellyfin.data.JellyfinServer
 import com.rpeters.jellyfin.data.SecureCredentialManager
-import io.mockk.*
+import com.rpeters.jellyfin.data.repository.common.ApiResult
+import io.mockk.coEvery
+import io.mockk.coJustRun
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import java.util.UUID
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.test.runTest
 import org.jellyfin.sdk.Jellyfin
-import org.junit.Assert.*
+import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.UserApiExtensionsKt
+import org.jellyfin.sdk.api.operations.UserApi
+import org.jellyfin.sdk.model.api.AuthenticationResult
+import org.jellyfin.sdk.model.api.UserDto
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class JellyfinAuthRepositoryTest {
 
+    private companion object {
+        private const val TOKEN_VALIDITY_DURATION_MS = 50 * 60 * 1000L
+        private const val BASE_TIME = 1_000L
+        private const val SERVER_URL = "https://demo.jellyfin.org"
+        private const val USERNAME = "testuser"
+        private const val PASSWORD = "password123"
+        private const val SERVER_ID = "server-id"
+        private const val ACCESS_TOKEN = "access-token"
+    }
+
     private lateinit var authRepository: JellyfinAuthRepository
-    private lateinit var mockCredentialManager: SecureCredentialManager
-    private lateinit var mockJellyfin: Jellyfin
+    private lateinit var credentialManager: SecureCredentialManager
+    private lateinit var jellyfin: Jellyfin
+    private lateinit var apiClient: ApiClient
+    private lateinit var userApi: UserApi
+
+    private var currentTime = BASE_TIME
 
     @Before
     fun setup() {
-        // Create mocks
-        mockCredentialManager = mockk(relaxed = true)
-        mockJellyfin = mockk(relaxed = true)
+        credentialManager = mockk(relaxUnitFun = true)
+        jellyfin = mockk(relaxUnitFun = true)
+        apiClient = mockk()
+        userApi = mockk()
 
-        // Initialize repository
-        authRepository = JellyfinAuthRepository(mockJellyfin, mockCredentialManager)
+        mockkStatic(UserApiExtensionsKt::class)
+        every { jellyfin.createApi(any(), any(), any(), any(), any()) } returns apiClient
+        every { apiClient.userApi } returns userApi
+
+        authRepository = JellyfinAuthRepository(jellyfin, credentialManager) { currentTime }
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
     }
 
     @Test
-    fun `JellyfinAuthRepository can be instantiated`() {
-        // Test that the repository can be created with mocked dependencies
-        assertNotNull("AuthRepository should be created", authRepository)
+    fun authenticateUser_updatesStateWithMockedDependencies() = runTest {
+        coEvery { userApi.authenticateUserByName(any()) } returns successfulAuthResponse()
+        coJustRun { credentialManager.savePassword(SERVER_URL, USERNAME, PASSWORD) }
+
+        val result = authRepository.authenticateUser(SERVER_URL, USERNAME, PASSWORD)
+
+        assertTrue(result is ApiResult.Success)
+        val server = authRepository.getCurrentServer()
+        assertNotNull(server)
+        assertEquals(SERVER_URL, server?.url)
+        assertEquals(USERNAME, server?.username)
+        assertEquals(ACCESS_TOKEN, server?.accessToken)
+        assertEquals(currentTime, server?.loginTimestamp)
+        coVerify(exactly = 1) { credentialManager.savePassword(SERVER_URL, USERNAME, PASSWORD) }
     }
 
     @Test
-    fun `repository has expected dependencies`() {
-        // Test that the repository is properly constructed with its dependencies
-        assertNotNull("Repository should have credential manager", mockCredentialManager)
-        assertNotNull("Repository should have Jellyfin instance", mockJellyfin)
+    fun isTokenExpired_reflectsInjectedTimeProvider() {
+        val initialServer = JellyfinServer(
+            id = SERVER_ID,
+            name = "Demo Server",
+            url = SERVER_URL,
+            isConnected = true,
+            username = USERNAME,
+            accessToken = ACCESS_TOKEN,
+            loginTimestamp = BASE_TIME,
+        )
+
+        authRepository.seedCurrentServer(initialServer)
+
+        assertFalse(authRepository.isTokenExpired())
+
+        currentTime = BASE_TIME + TOKEN_VALIDITY_DURATION_MS + 1
+
+        assertTrue(authRepository.isTokenExpired())
     }
 
     @Test
-    fun `currentServer flow is accessible`() {
-        // Test that the currentServer StateFlow is accessible
-        val currentServer = authRepository.currentServer
-        assertNotNull("CurrentServer flow should be accessible", currentServer)
+    fun forceReAuthenticate_runsOnceAcrossConcurrentCallers() = runTest {
+        val expiredServer = JellyfinServer(
+            id = SERVER_ID,
+            name = "Demo Server",
+            url = SERVER_URL,
+            isConnected = true,
+            username = USERNAME,
+            accessToken = null,
+            loginTimestamp = BASE_TIME - TOKEN_VALIDITY_DURATION_MS - 1,
+        )
+        authRepository.seedCurrentServer(expiredServer)
+
+        coEvery { credentialManager.getPassword(SERVER_URL, USERNAME) } returns PASSWORD
+        coEvery { userApi.authenticateUserByName(any()) } returns successfulAuthResponse()
+        coJustRun { credentialManager.savePassword(SERVER_URL, USERNAME, PASSWORD) }
+
+        currentTime = expiredServer.loginTimestamp!! + TOKEN_VALIDITY_DURATION_MS + 10
+
+        val results = List(10) { async { authRepository.forceReAuthenticate() } }.awaitAll()
+
+        assertTrue(results.all { it })
+        coVerify(exactly = 1) { credentialManager.getPassword(SERVER_URL, USERNAME) }
     }
 
     @Test
-    fun `isConnected flow is accessible`() {
-        // Test that the isConnected StateFlow is accessible
-        val isConnected = authRepository.isConnected
-        assertNotNull("IsConnected flow should be accessible", isConnected)
+    fun forceReAuthenticate_returnsFalseWhenPasswordMissing() = runTest {
+        val initialServer = JellyfinServer(
+            id = SERVER_ID,
+            name = "Demo Server",
+            url = SERVER_URL,
+            isConnected = true,
+            username = USERNAME,
+            accessToken = ACCESS_TOKEN,
+            loginTimestamp = BASE_TIME - TOKEN_VALIDITY_DURATION_MS - 1,
+        )
+        authRepository.seedCurrentServer(initialServer)
+
+        coEvery { credentialManager.getPassword(SERVER_URL, USERNAME) } returns null
+
+        currentTime = BASE_TIME + TOKEN_VALIDITY_DURATION_MS + 100
+
+        val success = authRepository.forceReAuthenticate()
+
+        assertFalse(success)
+        assertEquals(initialServer, authRepository.getCurrentServer())
     }
 
     @Test
-    fun `logout method is accessible`() = runTest {
-        // Test that logout method exists and can be called
-        try {
-            authRepository.logout()
-        } catch (e: Exception) {
-            fail("Logout should not throw exceptions: ${e.message}")
-        }
+    fun authenticateUser_propagatesApiErrorsWithoutMutatingState() = runTest {
+        coEvery { userApi.authenticateUserByName(any()) } throws IllegalStateException("boom")
+
+        val result = authRepository.authenticateUser(SERVER_URL, USERNAME, PASSWORD)
+
+        assertTrue(result is ApiResult.Error)
+        assertNull(authRepository.getCurrentServer())
     }
 
-    @Test
-    fun `authenticateUser method exists and handles parameters`() = runTest {
-        // Test that authenticateUser method exists and can handle basic inputs
-        try {
-            val result = authRepository.authenticateUser(
-                "https://demo.jellyfin.org",
-                "testuser",
-                "testpass",
-            )
-            // The result might be an error due to mocking, but the method should exist
-            assertNotNull("AuthenticateUser should return a result", result)
-        } catch (e: Exception) {
-            // Expected with mocked dependencies
-            assertTrue("Exception should be meaningful", e.message?.isNotEmpty() == true)
-        }
-    }
+    private fun successfulAuthResponse(): Response<AuthenticationResult> {
+        val user = UserDto(
+            name = USERNAME,
+            serverId = SERVER_ID,
+            serverName = "Demo",
+            id = UUID.randomUUID(),
+            primaryImageTag = null,
+            hasPassword = true,
+            hasConfiguredPassword = true,
+            hasConfiguredEasyPassword = false,
+        )
 
-    @Test
-    fun `authentication methods exist and handle parameters`() = runTest {
-        // Test that authentication methods exist and can handle basic parameters
-        try {
-            // Test that authenticate method exists - we'll just verify it doesn't crash on creation
-            authRepository.logout() // This method should exist and be callable
-        } catch (e: Exception) {
-            // If there are exceptions, they should be meaningful
-            assertTrue("Exception should be meaningful", e.message?.isNotEmpty() == true)
-        }
+        val authResult = AuthenticationResult(
+            user = user,
+            accessToken = ACCESS_TOKEN,
+            serverId = SERVER_ID,
+        )
+
+        return Response(authResult, 200, emptyMap())
     }
 }


### PR DESCRIPTION
## Summary
- inject a time provider into JellyfinAuthRepository and add a test-only seeding helper for current server state
- mock Jellyfin and credential storage dependencies in unit tests to exercise authentication success, token expiry, and concurrent refresh logic
- cover negative paths for missing stored credentials and API authentication failures

## Testing
- `./gradlew testDebugUnitTest` *(fails: Android SDK not configured in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc5045f5c08327b509b1987506fef1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - More accurate session expiration checks reduce unexpected logouts.
  - Concurrent re-authentication attempts are consolidated to prevent duplicate prompts or repeated network calls.

- Refactor
  - Improved time handling within authentication to enhance reliability and consistency across devices.

- Tests
  - Added comprehensive test coverage for authentication flows, token expiry behavior, error handling, and concurrent re-authentication scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->