### PR TITLE
feat: improve adaptive tv and tablet layouts

### DIFF
--- a/PHASE_1_1_ADAPTIVE_QA_CHECKLIST.md
+++ b/PHASE_1_1_ADAPTIVE_QA_CHECKLIST.md
@@ -1,0 +1,31 @@
+# Phase 1.1 Adaptive Layout QA Checklist
+
+## TV 1080p (Landscape)
+- Launch the Jellyfin Android TV app on a 1920×1080 display or emulator.
+- Verify the home screen uses carousel rows with focusable cards sized for TV (large spacing, 56–64 dp gutters).
+- Confirm that D-pad navigation preserves focus position when moving between carousels and returning from detail screens.
+- Ensure libraries row appears after media carousels and respects TV padding.
+- Validate that error, empty, and loading states still appear full-screen.
+
+## Tablet Portrait (e.g., 1280×800)
+- Open the app on a tablet in portrait orientation.
+- Confirm the layout switches to dual-pane grid mode with at least two columns and a visible detail pane on the right.
+- Focus different cards and verify the detail pane updates without losing grid focus.
+- Rotate back to TV layout (force landscape) and ensure initial focus returns to the last section.
+
+## Tablet Landscape / Desktop-width (e.g., 2560×1600)
+- Use landscape orientation or desktop window with expanded width.
+- Ensure the grid expands to additional columns (3–4) while the detail pane remains visible.
+- Verify spacing/padding tighten appropriately compared to TV mode.
+- Check that navigation drawer/rail choices align with the width class.
+
+## Foldable / Book Posture
+- Test on a foldable emulator (e.g., Pixel Fold) in book or tabletop posture.
+- Confirm the app treats the posture as tablet/dual-pane: grid on one side, detail pane on the other.
+- Close and reopen the device to ensure focus state persists across posture changes.
+- Validate navigation gestures or D-pad still target the focused grid item after posture transitions.
+
+## General Regression Checks
+- Switch between tablet and TV layouts and confirm focus restoration selects the previously focused carousel/grid item.
+- Verify carousel item sizing adapts (200–240 dp width) based on form factor and orientation.
+- Confirm there are no crashes when `WindowLayoutInfo` reports no folding features.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -82,6 +82,7 @@ dependencies {
     implementation(libs.androidx.material3.adaptive.layout)
     implementation(libs.androidx.material3.adaptive.navigation)
     implementation(libs.androidx.material3.window.size)
+    implementation(libs.androidx.window)
 
     // Material 3 Expressive Components (2024-2025)
     // Note: Some components not yet available in stable releases

--- a/app/src/main/java/com/rpeters/jellyfin/ui/components/tv/TvContentCarousel.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/components/tv/TvContentCarousel.kt
@@ -32,8 +32,8 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.rpeters.jellyfin.ui.adaptive.AdaptiveLayoutConfig
-import com.rpeters.jellyfin.ui.tv.TvFocusableCarousel
 import com.rpeters.jellyfin.ui.tv.TvFocusManager
+import com.rpeters.jellyfin.ui.tv.TvFocusableCarousel
 import com.rpeters.jellyfin.ui.viewmodel.MainAppViewModel
 import org.jellyfin.sdk.model.api.BaseItemDto
 import androidx.tv.material3.Card as TvCard
@@ -138,13 +138,13 @@ fun TvContentCard(
             },
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            TvCard(
-                onClick = { onItemSelect() },
-                modifier = Modifier.size(posterWidth, posterHeight),
-                colors = TvCardDefaults.colors(
-                    containerColor = TvMaterialTheme.colorScheme.surfaceVariant,
-                ),
+    ) {
+        TvCard(
+            onClick = { onItemSelect() },
+            modifier = Modifier.size(posterWidth, posterHeight),
+            colors = TvCardDefaults.colors(
+                containerColor = TvMaterialTheme.colorScheme.surfaceVariant,
+            ),
             glow = TvCardDefaults.glow(
                 focusedGlow = androidx.tv.material3.Glow(
                     elevationColor = if (isFocused) TvMaterialTheme.colorScheme.primary else TvMaterialTheme.colorScheme.surface,

--- a/app/src/main/java/com/rpeters/jellyfin/ui/components/tv/TvContentCarousel.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/components/tv/TvContentCarousel.kt
@@ -4,12 +4,13 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -23,13 +24,16 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
+import com.rpeters.jellyfin.ui.adaptive.AdaptiveLayoutConfig
 import com.rpeters.jellyfin.ui.tv.TvFocusableCarousel
-import com.rpeters.jellyfin.ui.tv.rememberTvFocusManager
+import com.rpeters.jellyfin.ui.tv.TvFocusManager
 import com.rpeters.jellyfin.ui.viewmodel.MainAppViewModel
 import org.jellyfin.sdk.model.api.BaseItemDto
 import androidx.tv.material3.Card as TvCard
@@ -41,6 +45,8 @@ import androidx.tv.material3.Text as TvText
 fun TvContentCarousel(
     items: List<BaseItemDto>,
     title: String,
+    layoutConfig: AdaptiveLayoutConfig,
+    focusManager: TvFocusManager,
     onItemFocus: (BaseItemDto) -> Unit = {},
     onItemSelect: (BaseItemDto) -> Unit,
     modifier: Modifier = Modifier,
@@ -59,15 +65,16 @@ fun TvContentCarousel(
         return
     }
 
-    val focusManager = rememberTvFocusManager()
     val lazyListState = rememberLazyListState()
     var focusedIndex by remember { mutableIntStateOf(0) }
+    val layoutDirection = LocalLayoutDirection.current
+    val horizontalPadding = layoutConfig.headerPadding.calculateStartPadding(layoutDirection)
 
     Column(modifier = modifier) {
         TvText(
             text = title,
             style = TvMaterialTheme.typography.headlineLarge,
-            modifier = Modifier.padding(start = 56.dp, top = 24.dp, bottom = 16.dp),
+            modifier = Modifier.padding(start = horizontalPadding, top = 24.dp, bottom = 16.dp),
         )
 
         TvFocusableCarousel(
@@ -75,6 +82,7 @@ fun TvContentCarousel(
             focusManager = focusManager,
             lazyListState = lazyListState,
             itemCount = items.size,
+            focusRequester = focusRequester,
             onFocusChanged = { isFocused, index ->
                 focusedIndex = index
                 if (isFocused && index < items.size) {
@@ -82,26 +90,25 @@ fun TvContentCarousel(
                 }
             },
         ) { focusModifier ->
-            val rowModifier = focusRequester?.let { focusModifier.focusRequester(it) } ?: focusModifier
-
             LazyRow(
                 state = lazyListState,
-                contentPadding = PaddingValues(horizontal = 56.dp),
-                horizontalArrangement = Arrangement.spacedBy(24.dp),
-                modifier = rowModifier,
+                contentPadding = PaddingValues(horizontal = horizontalPadding),
+                horizontalArrangement = Arrangement.spacedBy(layoutConfig.spacing),
+                modifier = focusModifier,
             ) {
-                items(items, key = { it.id?.toString() ?: "" }) { item ->
-                    val itemIndex = items.indexOf(item)
+                itemsIndexed(items, key = { index, item -> item.id?.toString() ?: index.toString() }) { index, item ->
                     TvContentCard(
                         item = item,
                         onItemFocus = {
-                            focusedIndex = itemIndex
+                            focusedIndex = index
                             onItemFocus(item)
                         },
                         onItemSelect = { onItemSelect(item) },
                         getImageUrl = viewModel::getImageUrl,
                         getSeriesImageUrl = viewModel::getSeriesImageUrl,
-                        isFocused = focusedIndex == itemIndex,
+                        isFocused = focusedIndex == index,
+                        posterWidth = layoutConfig.carouselItemWidth,
+                        posterHeight = layoutConfig.carouselItemHeight,
                     )
                 }
             }
@@ -118,10 +125,12 @@ fun TvContentCard(
     getSeriesImageUrl: (BaseItemDto) -> String?,
     modifier: Modifier = Modifier,
     isFocused: Boolean = false,
+    posterWidth: Dp = 240.dp,
+    posterHeight: Dp = 360.dp,
 ) {
     Column(
         modifier = modifier
-            .width(240.dp)
+            .width(posterWidth)
             .onFocusChanged { focusState ->
                 if (focusState.isFocused) {
                     onItemFocus()
@@ -129,13 +138,13 @@ fun TvContentCard(
             },
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
-        TvCard(
-            onClick = { onItemSelect() },
-            modifier = Modifier.size(240.dp, 360.dp),
-            colors = TvCardDefaults.colors(
-                containerColor = TvMaterialTheme.colorScheme.surfaceVariant,
-            ),
+        ) {
+            TvCard(
+                onClick = { onItemSelect() },
+                modifier = Modifier.size(posterWidth, posterHeight),
+                colors = TvCardDefaults.colors(
+                    containerColor = TvMaterialTheme.colorScheme.surfaceVariant,
+                ),
             glow = TvCardDefaults.glow(
                 focusedGlow = androidx.tv.material3.Glow(
                     elevationColor = if (isFocused) TvMaterialTheme.colorScheme.primary else TvMaterialTheme.colorScheme.surface,

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/tv/TvHomeScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/tv/TvHomeScreen.kt
@@ -20,8 +20,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
-import com.rpeters.jellyfin.ui.adaptive.rememberWindowLayoutInfo
 import com.rpeters.jellyfin.ui.adaptive.rememberAdaptiveLayoutConfig
+import com.rpeters.jellyfin.ui.adaptive.rememberWindowLayoutInfo
 import com.rpeters.jellyfin.ui.components.tv.TvEmptyState
 import com.rpeters.jellyfin.ui.components.tv.TvErrorBanner
 import com.rpeters.jellyfin.ui.components.tv.TvFullScreenLoading

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/tv/TvHomeScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/tv/TvHomeScreen.kt
@@ -7,8 +7,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.Composable
@@ -22,11 +20,14 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import com.rpeters.jellyfin.ui.adaptive.rememberWindowLayoutInfo
 import com.rpeters.jellyfin.ui.adaptive.rememberAdaptiveLayoutConfig
-import com.rpeters.jellyfin.ui.components.tv.TvContentCarousel
 import com.rpeters.jellyfin.ui.components.tv.TvEmptyState
 import com.rpeters.jellyfin.ui.components.tv.TvErrorBanner
 import com.rpeters.jellyfin.ui.components.tv.TvFullScreenLoading
+import com.rpeters.jellyfin.ui.screens.tv.adaptive.TabletHomeContent
+import com.rpeters.jellyfin.ui.screens.tv.adaptive.TvCarouselHomeContent
+import com.rpeters.jellyfin.ui.screens.tv.adaptive.TvHomeMediaSection
 import com.rpeters.jellyfin.ui.tv.TvScreenFocusScope
 import com.rpeters.jellyfin.ui.tv.rememberTvFocusManager
 import com.rpeters.jellyfin.ui.tv.requestInitialFocus
@@ -54,7 +55,8 @@ fun TvHomeScreen(
     val tvFocusManager = rememberTvFocusManager()
     val context = LocalContext.current
     val windowSizeClass = calculateWindowSizeClass(context as androidx.activity.ComponentActivity)
-    val layoutConfig = rememberAdaptiveLayoutConfig(windowSizeClass)
+    val windowLayoutInfo = rememberWindowLayoutInfo()
+    val layoutConfig = rememberAdaptiveLayoutConfig(windowSizeClass, windowLayoutInfo)
 
     // Ensure initial data is loaded when entering the TV home screen
     androidx.compose.runtime.LaunchedEffect(Unit) {
@@ -67,16 +69,38 @@ fun TvHomeScreen(
     val allMovies = appState.allMovies.take(10)
     val allTvShows = appState.allTVShows.take(10)
 
-    val firstCarouselId = when {
-        recentMovies.isNotEmpty() -> RECENT_MOVIES_ID
-        recentTvShows.isNotEmpty() -> RECENT_TV_SHOWS_ID
-        allMovies.isNotEmpty() -> ALL_MOVIES_ID
-        allTvShows.isNotEmpty() -> ALL_TV_SHOWS_ID
-        else -> null
-    }
+    val sections = listOf(
+        TvHomeMediaSection(
+            id = RECENT_MOVIES_ID,
+            title = "Recently Added Movies",
+            items = recentMovies,
+            isLoading = appState.isLoading,
+        ),
+        TvHomeMediaSection(
+            id = RECENT_TV_SHOWS_ID,
+            title = "Recently Added TV Shows",
+            items = recentTvShows,
+            isLoading = appState.isLoading,
+        ),
+        TvHomeMediaSection(
+            id = ALL_MOVIES_ID,
+            title = "Movies",
+            items = allMovies,
+            isLoading = appState.isLoadingMovies,
+        ),
+        TvHomeMediaSection(
+            id = ALL_TV_SHOWS_ID,
+            title = "TV Shows",
+            items = allTvShows,
+            isLoading = appState.isLoadingTVShows,
+        ),
+    ).filter { it.items.isNotEmpty() || it.isLoading }
 
-    val initialFocusRequester = remember { FocusRequester() }
-    initialFocusRequester.requestInitialFocus(condition = firstCarouselId != null)
+    val firstSectionId = sections.firstOrNull()?.id
+    val initialFocusRequester = remember(layoutConfig.shouldShowDualPane) { FocusRequester() }
+    initialFocusRequester.requestInitialFocus(
+        condition = firstSectionId != null && layoutConfig.supportsFocusNavigation,
+    )
 
     TvScreenFocusScope(
         screenKey = "tv_home",
@@ -124,81 +148,51 @@ fun TvHomeScreen(
                 return@Box
             }
 
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .verticalScroll(rememberScrollState())
-                    .padding(bottom = 48.dp),
-                verticalArrangement = Arrangement.spacedBy(layoutConfig.spacing),
-            ) {
-                // Welcome header with adaptive padding
-                TvHomeHeader(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(layoutConfig.headerPadding),
-                )
-
-                // Recently added movies
-                TvContentCarousel(
-                    items = recentMovies,
-                    title = "Recently Added Movies",
-                    onItemFocus = { /* Handle focus if needed */ },
+            if (layoutConfig.shouldShowDualPane) {
+                TabletHomeContent(
+                    layoutConfig = layoutConfig,
+                    sections = sections,
+                    focusManager = tvFocusManager,
+                    modifier = Modifier.fillMaxSize(),
+                    header = {
+                        TvHomeHeader(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(layoutConfig.headerPadding),
+                        )
+                    },
                     onItemSelect = { item ->
                         item.id?.let { onItemSelect(it.toString()) }
                     },
-                    carouselId = RECENT_MOVIES_ID,
-                    isLoading = appState.isLoading,
-                    focusRequester = initialFocusRequester.takeIf { firstCarouselId == RECENT_MOVIES_ID },
+                    getImageUrl = viewModel::getImageUrl,
+                    getSeriesImageUrl = viewModel::getSeriesImageUrl,
+                    libraries = appState.libraries,
+                    onLibrarySelect = onLibrarySelect,
+                    isLoadingLibraries = appState.isLoading,
+                    initialFocusRequester = initialFocusRequester.takeIf { firstSectionId != null },
                 )
-
-                // TV Shows
-                TvContentCarousel(
-                    items = recentTvShows,
-                    title = "Recently Added TV Shows",
-                    onItemFocus = { /* Handle focus if needed */ },
+            } else {
+                TvCarouselHomeContent(
+                    layoutConfig = layoutConfig,
+                    sections = sections,
+                    focusManager = tvFocusManager,
+                    modifier = Modifier.fillMaxSize(),
+                    header = {
+                        TvHomeHeader(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(layoutConfig.headerPadding),
+                        )
+                    },
                     onItemSelect = { item ->
                         item.id?.let { onItemSelect(it.toString()) }
                     },
-                    carouselId = RECENT_TV_SHOWS_ID,
-                    isLoading = appState.isLoading,
-                    focusRequester = initialFocusRequester.takeIf { firstCarouselId == RECENT_TV_SHOWS_ID },
+                    libraries = appState.libraries,
+                    onLibrarySelect = onLibrarySelect,
+                    isLoadingLibraries = appState.isLoading,
+                    initialFocusRequester = initialFocusRequester,
+                    firstSectionId = firstSectionId,
                 )
-
-                // All movies
-                TvContentCarousel(
-                    items = allMovies,
-                    title = "Movies",
-                    onItemFocus = { /* Handle focus if needed */ },
-                    onItemSelect = { item ->
-                        item.id?.let { onItemSelect(it.toString()) }
-                    },
-                    carouselId = ALL_MOVIES_ID,
-                    isLoading = appState.isLoadingMovies,
-                    focusRequester = initialFocusRequester.takeIf { firstCarouselId == ALL_MOVIES_ID },
-                )
-
-                // All TV shows
-                TvContentCarousel(
-                    items = allTvShows,
-                    title = "TV Shows",
-                    onItemFocus = { /* Handle focus if needed */ },
-                    onItemSelect = { item ->
-                        item.id?.let { onItemSelect(it.toString()) }
-                    },
-                    carouselId = ALL_TV_SHOWS_ID,
-                    isLoading = appState.isLoadingTVShows,
-                    focusRequester = initialFocusRequester.takeIf { firstCarouselId == ALL_TV_SHOWS_ID },
-                )
-
-                // Libraries section
-                if (appState.libraries.isNotEmpty()) {
-                    TvLibrariesSection(
-                        libraries = appState.libraries,
-                        onLibrarySelect = onLibrarySelect,
-                        modifier = Modifier.fillMaxWidth(),
-                        isLoading = appState.isLoading,
-                    )
-                }
             }
         }
     }

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/tv/adaptive/TvAdaptiveHomeContent.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/tv/adaptive/TvAdaptiveHomeContent.kt
@@ -27,8 +27,8 @@ import com.rpeters.jellyfin.ui.components.tv.TvContentCard
 import com.rpeters.jellyfin.ui.components.tv.TvContentCarousel
 import com.rpeters.jellyfin.ui.components.tv.TvSkeletonCarousel
 import com.rpeters.jellyfin.ui.screens.tv.TvLibrariesSection
-import com.rpeters.jellyfin.ui.tv.TvFocusableGrid
 import com.rpeters.jellyfin.ui.tv.TvFocusManager
+import com.rpeters.jellyfin.ui.tv.TvFocusableGrid
 import org.jellyfin.sdk.model.api.BaseItemDto
 import androidx.tv.material3.MaterialTheme as TvMaterialTheme
 import androidx.tv.material3.Text as TvText

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/tv/adaptive/TvAdaptiveHomeContent.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/tv/adaptive/TvAdaptiveHomeContent.kt
@@ -1,0 +1,326 @@
+package com.rpeters.jellyfin.ui.screens.tv.adaptive
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.calculateStartPadding
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.itemsIndexed
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.text.style.TextOverflow
+import com.rpeters.jellyfin.ui.adaptive.AdaptiveLayoutConfig
+import com.rpeters.jellyfin.ui.components.tv.TvContentCard
+import com.rpeters.jellyfin.ui.components.tv.TvContentCarousel
+import com.rpeters.jellyfin.ui.components.tv.TvSkeletonCarousel
+import com.rpeters.jellyfin.ui.screens.tv.TvLibrariesSection
+import com.rpeters.jellyfin.ui.tv.TvFocusableGrid
+import com.rpeters.jellyfin.ui.tv.TvFocusManager
+import org.jellyfin.sdk.model.api.BaseItemDto
+import androidx.tv.material3.MaterialTheme as TvMaterialTheme
+import androidx.tv.material3.Text as TvText
+
+/**
+ * Shared representation for TV home content sections.
+ */
+data class TvHomeMediaSection(
+    val id: String,
+    val title: String,
+    val items: List<BaseItemDto>,
+    val isLoading: Boolean,
+)
+
+/**
+ * TV-first carousel layout that keeps compatibility with existing focus behavior.
+ */
+@Composable
+fun TvCarouselHomeContent(
+    layoutConfig: AdaptiveLayoutConfig,
+    sections: List<TvHomeMediaSection>,
+    focusManager: TvFocusManager,
+    modifier: Modifier = Modifier,
+    header: @Composable () -> Unit,
+    onItemSelect: (BaseItemDto) -> Unit,
+    libraries: List<BaseItemDto>,
+    onLibrarySelect: (String) -> Unit,
+    isLoadingLibraries: Boolean,
+    initialFocusRequester: FocusRequester,
+    firstSectionId: String?,
+) {
+    val scrollState = rememberScrollState()
+
+    Column(
+        modifier = modifier
+            .verticalScroll(scrollState)
+            .padding(layoutConfig.contentPadding)
+            .padding(bottom = layoutConfig.spacing),
+        verticalArrangement = Arrangement.spacedBy(layoutConfig.spacing),
+    ) {
+        header()
+
+        sections.forEach { section ->
+            TvContentCardSection(
+                section = section,
+                layoutConfig = layoutConfig,
+                focusManager = focusManager,
+                onItemSelect = onItemSelect,
+                initialFocusRequester = initialFocusRequester.takeIf { firstSectionId == section.id },
+            )
+        }
+
+        if (libraries.isNotEmpty()) {
+            TvLibrariesSection(
+                libraries = libraries,
+                onLibrarySelect = onLibrarySelect,
+                modifier = Modifier.fillMaxWidth(),
+                isLoading = isLoadingLibraries,
+            )
+        }
+    }
+}
+
+@Composable
+private fun TvContentCardSection(
+    section: TvHomeMediaSection,
+    layoutConfig: AdaptiveLayoutConfig,
+    focusManager: TvFocusManager,
+    onItemSelect: (BaseItemDto) -> Unit,
+    initialFocusRequester: FocusRequester?,
+) {
+    if (section.isLoading && section.items.isEmpty()) {
+        TvSkeletonCarousel(
+            title = section.title,
+            itemCount = layoutConfig.gridColumns * layoutConfig.maxRows,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        return
+    }
+
+    if (section.items.isEmpty()) {
+        return
+    }
+
+    val carouselId = focusManager.getCarouselId(section.id)
+
+    TvContentCarousel(
+        items = section.items,
+        title = section.title,
+        layoutConfig = layoutConfig,
+        focusManager = focusManager,
+        onItemSelect = onItemSelect,
+        carouselId = carouselId,
+        isLoading = section.isLoading,
+        focusRequester = initialFocusRequester,
+    )
+}
+
+/**
+ * Tablet and foldable-first layout using multi-column grids with a simultaneous detail pane.
+ */
+@Composable
+fun TabletHomeContent(
+    layoutConfig: AdaptiveLayoutConfig,
+    sections: List<TvHomeMediaSection>,
+    focusManager: TvFocusManager,
+    modifier: Modifier = Modifier,
+    header: @Composable () -> Unit,
+    onItemSelect: (BaseItemDto) -> Unit,
+    getImageUrl: (BaseItemDto) -> String?,
+    getSeriesImageUrl: (BaseItemDto) -> String?,
+    libraries: List<BaseItemDto>,
+    onLibrarySelect: (String) -> Unit,
+    isLoadingLibraries: Boolean,
+    initialFocusRequester: FocusRequester? = null,
+) {
+    val scrollState = rememberScrollState()
+
+    Column(
+        modifier = modifier
+            .verticalScroll(scrollState)
+            .padding(layoutConfig.contentPadding)
+            .padding(bottom = layoutConfig.spacing),
+        verticalArrangement = Arrangement.spacedBy(layoutConfig.spacing),
+    ) {
+        header()
+
+        sections.forEachIndexed { index, section ->
+            TabletMediaSection(
+                section = section,
+                layoutConfig = layoutConfig,
+                focusManager = focusManager,
+                onItemSelect = onItemSelect,
+                getImageUrl = getImageUrl,
+                getSeriesImageUrl = getSeriesImageUrl,
+                focusRequester = initialFocusRequester.takeIf { index == 0 },
+            )
+        }
+
+        if (libraries.isNotEmpty()) {
+            TvLibrariesSection(
+                libraries = libraries,
+                onLibrarySelect = onLibrarySelect,
+                modifier = Modifier.fillMaxWidth(),
+                isLoading = isLoadingLibraries,
+            )
+        }
+    }
+}
+
+@Composable
+private fun TabletMediaSection(
+    section: TvHomeMediaSection,
+    layoutConfig: AdaptiveLayoutConfig,
+    focusManager: TvFocusManager,
+    onItemSelect: (BaseItemDto) -> Unit,
+    getImageUrl: (BaseItemDto) -> String?,
+    getSeriesImageUrl: (BaseItemDto) -> String?,
+    focusRequester: FocusRequester?,
+) {
+    if (section.isLoading && section.items.isEmpty()) {
+        TvSkeletonCarousel(
+            title = section.title,
+            itemCount = layoutConfig.gridColumns * layoutConfig.maxRows,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        return
+    }
+
+    if (section.items.isEmpty()) {
+        return
+    }
+
+    val items = section.items
+    val layoutDirection = LocalLayoutDirection.current
+    val titlePadding = layoutConfig.headerPadding.calculateStartPadding(layoutDirection)
+    val gridState = rememberLazyGridState()
+    var focusedIndex by rememberSaveable(section.id, layoutConfig.detailPaneVisibility) {
+        mutableIntStateOf(0)
+    }
+
+    val carouselId = focusManager.getCarouselId(section.id)
+    val columns = layoutConfig.gridColumns.coerceAtLeast(2)
+    val detailItem = items.getOrNull(focusedIndex.coerceIn(0, items.lastIndex))
+
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(layoutConfig.spacing),
+    ) {
+        TvText(
+            text = section.title,
+            style = TvMaterialTheme.typography.headlineLarge,
+            modifier = Modifier.padding(start = titlePadding),
+        )
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(layoutConfig.spacing),
+            verticalAlignment = Alignment.Top,
+        ) {
+            TvFocusableGrid(
+                gridId = carouselId,
+                focusManager = focusManager,
+                lazyGridState = gridState,
+                itemCount = items.size,
+                columnsCount = columns,
+                focusRequester = focusRequester,
+                onFocusChanged = { isFocused, index ->
+                    if (isFocused && index in items.indices) {
+                        focusedIndex = index
+                    }
+                },
+            ) { focusModifier ->
+                LazyVerticalGrid(
+                    columns = GridCells.Fixed(columns),
+                    state = gridState,
+                    modifier = focusModifier
+                        .weight(0.68f)
+                        .fillMaxHeight(),
+                    contentPadding = PaddingValues(bottom = layoutConfig.spacing),
+                    verticalArrangement = Arrangement.spacedBy(layoutConfig.spacing),
+                    horizontalArrangement = Arrangement.spacedBy(layoutConfig.spacing),
+                ) {
+                    itemsIndexed(items, key = { index, item -> item.id?.toString() ?: index.toString() }) { index, item ->
+                        TvContentCard(
+                            item = item,
+                            onItemFocus = { focusedIndex = index },
+                            onItemSelect = { onItemSelect(item) },
+                            getImageUrl = getImageUrl,
+                            getSeriesImageUrl = getSeriesImageUrl,
+                            isFocused = focusedIndex == index,
+                            posterWidth = layoutConfig.carouselItemWidth,
+                            posterHeight = layoutConfig.carouselItemHeight,
+                        )
+                    }
+                }
+            }
+
+            TabletDetailPane(
+                item = detailItem,
+                layoutConfig = layoutConfig,
+            )
+        }
+    }
+}
+
+@Composable
+private fun TabletDetailPane(
+    item: BaseItemDto?,
+    layoutConfig: AdaptiveLayoutConfig,
+) {
+    Column(
+        modifier = Modifier
+            .weight(0.32f)
+            .fillMaxHeight()
+            .padding(PaddingValues(horizontal = layoutConfig.spacing)),
+        verticalArrangement = Arrangement.spacedBy(layoutConfig.spacing / 2),
+        horizontalAlignment = Alignment.Start,
+    ) {
+        if (item == null) {
+            TvText(
+                text = "Select an item to see more details",
+                style = TvMaterialTheme.typography.bodyLarge,
+                color = TvMaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            return
+        }
+
+        TvText(
+            text = item.name ?: "Unknown",
+            style = TvMaterialTheme.typography.headlineMedium,
+            color = TvMaterialTheme.colorScheme.onSurface,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+        )
+
+        item.productionYear?.let { year ->
+            TvText(
+                text = year.toString(),
+                style = TvMaterialTheme.typography.titleMedium,
+                color = TvMaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        item.overview?.takeIf { it.isNotBlank() }?.let { overview ->
+            TvText(
+                text = overview,
+                style = TvMaterialTheme.typography.bodyMedium,
+                color = TvMaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 6,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/rpeters/jellyfin/ui/tv/TvFocusManager.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/tv/TvFocusManager.kt
@@ -132,10 +132,11 @@ fun TvFocusableCarousel(
     focusManager: TvFocusManager,
     lazyListState: LazyListState,
     itemCount: Int,
+    focusRequester: FocusRequester? = null,
     onFocusChanged: (Boolean, Int) -> Unit = { _, _ -> },
     content: @Composable (Modifier) -> Unit,
 ) {
-    val focusRequester = remember { FocusRequester() }
+    val actualFocusRequester = remember(focusRequester) { focusRequester ?: FocusRequester() }
     var isFocused by remember { mutableStateOf(false) }
     var focusedIndex by rememberSaveable { mutableIntStateOf(0) }
 
@@ -157,7 +158,7 @@ fun TvFocusableCarousel(
     }
 
     val focusModifier = Modifier
-        .focusRequester(focusRequester)
+        .focusRequester(actualFocusRequester)
         .focusable()
         .onFocusChanged { focusState ->
             isFocused = focusState.isFocused
@@ -191,10 +192,11 @@ fun TvFocusableGrid(
     lazyGridState: LazyGridState,
     itemCount: Int,
     columnsCount: Int,
+    focusRequester: FocusRequester? = null,
     onFocusChanged: (Boolean, Int) -> Unit = { _, _ -> },
     content: @Composable (Modifier) -> Unit,
 ) {
-    val focusRequester = remember { FocusRequester() }
+    val actualFocusRequester = remember(focusRequester) { focusRequester ?: FocusRequester() }
     var isFocused by remember { mutableStateOf(false) }
     var focusedIndex by rememberSaveable { mutableIntStateOf(0) }
 
@@ -216,7 +218,7 @@ fun TvFocusableGrid(
     }
 
     val focusModifier = Modifier
-        .focusRequester(focusRequester)
+        .focusRequester(actualFocusRequester)
         .focusable()
         .onFocusChanged { focusState ->
             isFocused = focusState.isFocused

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,6 +37,7 @@ androidxArchCoreTest = "2.2.0"
 androidxTvMaterial = "1.1.0-alpha01"
 paging = "3.4.0-alpha04"
 sdk = "36"
+window = "1.3.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -63,6 +64,7 @@ androidx-material3-adaptive = { group = "androidx.compose.material3.adaptive", n
 androidx-material3-adaptive-layout = { group = "androidx.compose.material3.adaptive", name = "adaptive-layout", version.ref = "material3Adaptive" }
 androidx-material3-adaptive-navigation = { group = "androidx.compose.material3.adaptive", name = "adaptive-navigation", version.ref = "material3Adaptive" }
 androidx-material3-window-size = { group = "androidx.compose.material3", name = "material3-window-size-class", version.ref = "material3WindowSizeClassVersion" }
+androidx-window = { group = "androidx.window", name = "window", version.ref = "window" }
 
 # Material 3 Expressive Components (2024-2025)
 # Note: Some components are not yet available in stable releases


### PR DESCRIPTION
## Summary
- enhance adaptive layout detection with posture-aware detail pane hints and dual-pane support
- refactor the TV home experience to switch between carousel and grid/detail layouts based on the adaptive config
- add a Phase 1.1 manual QA checklist covering TV, tablet, and foldable scenarios

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc504960a083279c335d874d20ebfe