### PR TITLE
Migrate downloads to modern storage APIs

### DIFF
--- a/app/src/test/java/com/rpeters/jellyfin/ui/utils/MediaDownloadManagerTest.kt
+++ b/app/src/test/java/com/rpeters/jellyfin/ui/utils/MediaDownloadManagerTest.kt
@@ -1,9 +1,13 @@
 package com.rpeters.jellyfin.ui.utils
 
 import android.content.Context
+import android.content.pm.PackageManager
 import android.os.Environment
+import androidx.core.content.ContextCompat
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemKind
 import org.junit.Assert.assertEquals
@@ -30,11 +34,18 @@ class MediaDownloadManagerTest {
         val context = mockk<Context>()
         every { context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS) } returns baseDir
 
+        mockkStatic(ContextCompat::class)
+        every { ContextCompat.checkSelfPermission(any(), any()) } returns PackageManager.PERMISSION_GRANTED
+
         val item = BaseItemDto(id = java.util.UUID.randomUUID(), name = "Video", type = BaseItemKind.MOVIE)
         val file = File(baseDir, "JellyfinAndroid/Movies/Video.mp4")
         file.parentFile?.mkdirs()
         file.writeText("data")
 
-        assertTrue(MediaDownloadManager.isDownloaded(context, item))
+        try {
+            assertTrue(MediaDownloadManager.isDownloaded(context, item, sdkInt = android.os.Build.VERSION_CODES.P))
+        } finally {
+            unmockkAll()
+        }
     }
 }


### PR DESCRIPTION
## Summary
- switch `MediaDownloadManager` to use MediaStore destinations on Android Q+ and surface content URIs for downloaded media
- add MediaStore helpers for storage accounting/cleanup and tighten permission checks for modern platform scopes
- update unit coverage to mock runtime permissions when verifying legacy download detection

## Testing
- ./gradlew testDebugUnitTest *(fails: missing Android SDK location in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f7cc10a9dc8327988951bb7e28dfeb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved download storage compatibility for Android 10+ devices
  * Enhanced storage permission detection for newer Android versions
  * Refined download verification logic across different device models
  * Maintained full backward compatibility with older Android devices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->