### PR TITLE
chore: align Retrofit stack with official converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ A modern, beautiful Android client for Jellyfin media servers built with Materia
 - **Async Programming:** Kotlin Coroutines 1.10.2
 
 ### **Networking & API**
-- **Jellyfin SDK:** 1.6.8 (Official Jellyfin Kotlin SDK)
-- **HTTP Client:** Retrofit 3.0.0 + OkHttp 5.1.0
+- **Jellyfin SDK:** 1.8.2 (Official Jellyfin Kotlin SDK)
+- **HTTP Client:** Retrofit 3.0.0 + OkHttp 5.3.0 (official Kotlinx Serialization converter)
 - **Serialization:** Kotlinx Serialization 1.9.0
 - **Image Loading:** Coil 2.7.0 with Compose integration
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 agp = "8.13.0"
 desugar_jdk_libs = "2.1.5"
 kotlin = "2.2.21"
-ksp = "2.2.21-1.0.29"
+ksp = "2.3.0"
 coreKtx = "1.17.0"
 junit = "4.13.2"
 junitVersion = "1.3.0"
@@ -76,7 +76,7 @@ androidx-window = { group = "androidx.window", name = "window", version.ref = "w
 # Jellyfin & Networking
 jellyfin-sdk = { group = "org.jellyfin.sdk", name = "jellyfin-core", version.ref = "jellyfinSdk" }
 retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
-retrofit-kotlinx-serialization = { group = "com.jakewharton.retrofit", name = "retrofit2-kotlinx-serialization-converter", version = "1.0.0" }
+retrofit-kotlinx-serialization = { group = "com.squareup.retrofit2", name = "converter-kotlinx-serialization", version.ref = "retrofit" }
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerialization" }


### PR DESCRIPTION
## Summary
- switch the Retrofit Kotlin serialization converter to the official com.squareup artifact so it stays in lockstep with Retrofit 3.0.0
- update the shared KSP plugin version alias to match the pluginManagement configuration
- refresh the README networking stack versions to reflect the current Retrofit/OkHttp/Jellyfin SDK setup

## Testing
- ./gradlew assembleDebug *(fails: Android SDK not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_6909475d85a88327b22e2102ff005757

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches to the official Retrofit Kotlinx Serialization converter, bumps KSP to 2.3.0, and updates README networking versions.
> 
> - **Build/Dependencies**:
>   - Replace `com.jakewharton:retrofit2-kotlinx-serialization-converter` with `com.squareup.retrofit2:converter-kotlinx-serialization` (version tied to `retrofit` 3.0.0) in `gradle/libs.versions.toml`.
>   - Bump `ksp` version to `2.3.0`.
> - **Docs**:
>   - Refresh `README.md` networking stack: `Jellyfin SDK 1.8.2`, `Retrofit 3.0.0 + OkHttp 5.3.0` with the official Kotlinx Serialization converter.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b736b288e3a6c07113d7b1f648d17b62091785b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Jellyfin SDK to version 1.8.2 for improved API compatibility
  * Updated networking and HTTP client dependencies to latest versions
  * Upgraded build tooling and adopted official Kotlin serialization integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->