### PR TITLE
fix: correct LibraryTypeScreen remember() dependencies for TV Shows

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/LibraryTypeScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/LibraryTypeScreen.kt
@@ -70,8 +70,9 @@ fun LibraryTypeScreen(
     var viewMode by remember { mutableStateOf(ViewMode.GRID) }
     var selectedFilter by remember { mutableStateOf(FilterType.getDefault()) }
 
-    // ✅ FIX: Use library-specific data instead of generic allItems
-    val libraryItems = remember(libraryType, appState.allMovies, appState.allTVShows, appState.allItems) {
+    // ✅ FIX: Use library-specific data from itemsByLibrary map
+    // The remember() must depend on itemsByLibrary since getLibraryTypeData() reads from that map
+    val libraryItems = remember(libraryType, appState.itemsByLibrary) {
         viewModel.getLibraryTypeData(libraryType)
     }
 


### PR DESCRIPTION
This pull request updates the `LibraryTypeScreen` to ensure that library-specific data is correctly used when displaying items. The main change is to make the component react to updates in the `itemsByLibrary` map, ensuring the displayed items stay in sync with the underlying data.

Data dependency fix:

* Changed the dependency array for the `remember` call in `LibraryTypeScreen` to use `appState.itemsByLibrary` instead of unrelated global collections, so that the displayed library items update correctly when the relevant data changes.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make `LibraryTypeScreen` recompute library items when `appState.itemsByLibrary` changes, ensuring library-specific data stays in sync.
> 
> - **LibraryTypeScreen**: Change `remember` dependencies to `remember(libraryType, appState.itemsByLibrary)` so `getLibraryTypeData()` reacts to library-specific updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a59a73955e1ff2bfdfad3e3542a9b2be9aacb577. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized library data handling for improved efficiency and more accurate dependency tracking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->