### PR TITLE
Add SearchViewModel unit tests

### DIFF
--- a/app/src/test/java/com/rpeters/jellyfin/ui/viewmodel/SearchViewModelTest.kt
+++ b/app/src/test/java/com/rpeters/jellyfin/ui/viewmodel/SearchViewModelTest.kt
@@ -1,6 +1,5 @@
 package com.rpeters.jellyfin.ui.viewmodel
 
-import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.rpeters.jellyfin.data.repository.JellyfinSearchRepository
 import com.rpeters.jellyfin.data.repository.common.ApiResult
 import io.mockk.MockKAnnotations
@@ -22,14 +21,10 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class SearchViewModelTest {
-
-    @get:Rule
-    val instantTaskExecutorRule = InstantTaskExecutorRule()
 
     @MockK
     private lateinit var searchRepository: JellyfinSearchRepository
@@ -50,7 +45,19 @@ class SearchViewModelTest {
     }
 
     @Test
-    fun `updateSearchQuery updates state and clears when blank`() = runTest {
+    fun `updateSearchQuery_withNonBlankQuery_updatesState`() = runTest {
+        viewModel.updateSearchQuery("matrix")
+
+        val state = viewModel.searchState.value
+        assertEquals("matrix", state.searchQuery)
+        assertTrue(state.searchResults.isEmpty())
+        assertFalse(state.isSearching)
+        assertFalse(state.hasSearched)
+        assertNull(state.errorMessage)
+    }
+
+    @Test
+    fun `updateSearchQuery_withBlankQueryAfterSearch_clearsState`() = runTest {
         coEvery { searchRepository.searchItems(any(), any(), any()) } returns ApiResult.Success(emptyList())
 
         viewModel.updateSearchQuery("matrix")
@@ -70,7 +77,7 @@ class SearchViewModelTest {
     }
 
     @Test
-    fun `performSearch updates results on success`() = runTest {
+    fun `performSearch_onSuccess_updatesResultsAndFlags`() = runTest {
         val items = listOf(mockk<BaseItemDto>())
         coEvery { searchRepository.searchItems("avatar", any(), any()) } returns ApiResult.Success(items)
 
@@ -85,7 +92,7 @@ class SearchViewModelTest {
     }
 
     @Test
-    fun `performSearch handles error response`() = runTest {
+    fun `performSearch_onError_setsErrorMessage`() = runTest {
         coEvery { searchRepository.searchItems("fail", any(), any()) } returns ApiResult.Error("network")
 
         viewModel.performSearch("fail")
@@ -97,7 +104,7 @@ class SearchViewModelTest {
     }
 
     @Test
-    fun `toggleContentType updates filters and triggers search`() = runTest {
+    fun `toggleContentType_withSelectedMovie_removesTypeAndTriggersSearch`() = runTest {
         coEvery { searchRepository.searchItems(any(), any(), any()) } returns ApiResult.Success(emptyList())
 
         viewModel.updateSearchQuery("comedy")
@@ -106,11 +113,31 @@ class SearchViewModelTest {
         val selectedTypes = viewModel.searchState.value.selectedContentTypes
         assertFalse(selectedTypes.contains(BaseItemKind.MOVIE))
 
-        coVerify { searchRepository.searchItems("comedy", match { BaseItemKind.MOVIE !in it }, 50) }
+        coVerify {
+            searchRepository.searchItems(
+                "comedy",
+                match { it.toSet() == setOf(BaseItemKind.SERIES, BaseItemKind.AUDIO, BaseItemKind.BOOK) },
+                50,
+            )
+        }
     }
 
     @Test
-    fun `clearSearch resets state`() {
+    fun `toggleContentType_withUnselectedType_addsTypeAndTriggersSearch`() = runTest {
+        coEvery { searchRepository.searchItems(any(), any(), any()) } returns ApiResult.Success(emptyList())
+
+        viewModel.updateSearchQuery("test")
+        viewModel.toggleContentType(BaseItemKind.MOVIE)
+        viewModel.toggleContentType(BaseItemKind.MOVIE)
+
+        val selectedTypes = viewModel.searchState.value.selectedContentTypes
+        assertTrue(selectedTypes.contains(BaseItemKind.MOVIE))
+
+        coVerify { searchRepository.searchItems("test", any(), 50) }
+    }
+
+    @Test
+    fun `clearSearch_always_resetsAllStateFields`() {
         viewModel.updateSearchQuery("something")
         viewModel.clearSearch()
 
@@ -123,7 +150,7 @@ class SearchViewModelTest {
     }
 
     @Test
-    fun `searchMovies delegates to repository`() = runTest {
+    fun `searchMovies_onSuccess_updatesResultsFromRepository`() = runTest {
         val movies = listOf(mockk<BaseItemDto>())
         coEvery { searchRepository.searchMovies("terminator") } returns ApiResult.Success(movies)
 
@@ -137,14 +164,28 @@ class SearchViewModelTest {
     }
 
     @Test
-    fun `searchTVShows handles repository error`() = runTest {
+    fun `searchMovies_onError_setsErrorMessage`() = runTest {
+        coEvery { searchRepository.searchMovies("terminator") } returns ApiResult.Error("network error")
+
+        viewModel.searchMovies("terminator")
+
+        val state = viewModel.searchState.value
+        assertFalse(state.isSearching)
+        assertEquals("network error", state.errorMessage)
+    }
+
+    @Test
+    fun `searchTVShows_onError_preservesResultsAndSetsError`() = runTest {
+        val shows = listOf(mockk<BaseItemDto>())
+        coEvery { searchRepository.searchTVShows("success") } returns ApiResult.Success(shows)
         coEvery { searchRepository.searchTVShows("lost") } returns ApiResult.Error("timeout")
 
+        viewModel.searchTVShows("success")
         viewModel.searchTVShows("lost")
 
         val state = viewModel.searchState.value
-        assertTrue(state.searchResults.isEmpty())
         assertFalse(state.isSearching)
+        assertEquals(shows, state.searchResults)
         assertEquals("timeout", state.errorMessage)
     }
 }


### PR DESCRIPTION
## Summary
- add unit tests for SearchViewModel covering search success, error handling, and filter toggles
- verify movie and TV show search paths delegate to the repository

## Testing
- `./gradlew testDebugUnitTest` *(fails: Android SDK path not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69372f9f71e48327bd484a1b66a8358b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for search behavior: query updates, preserving/clearing results, success and error handling, content-type toggling, clearing search state, and separate movie/TV search paths to validate state transitions and repository interactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->