### PR TITLE
Add stable keys to Compose lazy lists

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/AlbumDetailScreen.kt
@@ -84,7 +84,7 @@ fun AlbumDetailScreen(
                 verticalArrangement = Arrangement.spacedBy(12.dp),
                 modifier = Modifier.fillMaxSize(),
             ) {
-                items(state.tracks) { track ->
+                items(state.tracks, key = { it.id ?: it.name.hashCode() }) { track ->
                     ExpressiveMediaCard(
                         title = track.name ?: "",
                         subtitle = track.albumArtist ?: track.artists?.firstOrNull() ?: "",

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/HomeScreen.kt
@@ -860,7 +860,7 @@ private fun PosterRowSection(
             contentPadding = PaddingValues(horizontal = 16.dp),
             horizontalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            items(items) { item ->
+            items(items, key = { it.id ?: it.name.hashCode() }) { item ->
                 PosterMediaCard(
                     item = item,
                     getImageUrl = getImageUrl,
@@ -901,7 +901,7 @@ private fun SquareRowSection(
             contentPadding = PaddingValues(horizontal = 16.dp),
             horizontalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            items(items) { item ->
+            items(items, key = { it.id ?: it.name.hashCode() }) { item ->
                 MediaCard(
                     item = item,
                     getImageUrl = getImageUrl,
@@ -940,7 +940,7 @@ private fun MediaRowSection(
             contentPadding = PaddingValues(horizontal = 16.dp),
             horizontalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            items(items) { item ->
+            items(items, key = { it.id ?: it.name.hashCode() }) { item ->
                 MediaCard(
                     item = item,
                     getImageUrl = getImageUrl,

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/HomeVideosScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/HomeVideosScreen.kt
@@ -229,7 +229,7 @@ fun HomeVideosGrid(
         horizontalArrangement = Arrangement.spacedBy(12.dp),
         modifier = modifier,
     ) {
-        items(homeVideosItems) { homeVideoItem ->
+        items(homeVideosItems, key = { it.id ?: it.name.hashCode() }) { homeVideoItem ->
             ExpressiveMediaCard(
                 title = homeVideoItem.name ?: "",
                 subtitle = homeVideoItem.type?.toString() ?: "",

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/LibraryScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/LibraryScreen.kt
@@ -148,7 +148,7 @@ fun LibraryScreen(
                                 .fillMaxWidth(),
                             verticalArrangement = Arrangement.spacedBy(12.dp),
                         ) {
-                            items(libraries) { library ->
+                            items(libraries, key = { it.id ?: it.name.hashCode() }) { library ->
                                 LibraryCard(
                                     library = library,
                                     getImageUrl = getImageUrl,

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/MovieDetailScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/MovieDetailScreen.kt
@@ -307,7 +307,7 @@ fun MovieDetailScreen(
                             horizontalArrangement = Arrangement.spacedBy(16.dp),
                             contentPadding = PaddingValues(horizontal = 4.dp),
                         ) {
-                            items(relatedItems.take(10)) { relatedMovie ->
+                            items(relatedItems.take(10), key = { it.id ?: it.name.hashCode() }) { relatedMovie ->
                                 val scale by animateFloatAsState(
                                     targetValue = 1.0f,
                                     animationSpec = MotionTokens.expressiveEnter,
@@ -605,7 +605,7 @@ private fun ExpressiveMovieInfoCard(
                     LazyRow(
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
                     ) {
-                        items(genres.take(3)) { genre ->
+                        items(genres.take(3), key = { it }) { genre ->
                             Surface(
                                 shape = RoundedCornerShape(20.dp),
                                 color = JellyfinTeal80.copy(alpha = 0.15f),

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/MusicScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/MusicScreen.kt
@@ -510,7 +510,7 @@ private fun MusicContent(
                 horizontalArrangement = Arrangement.spacedBy(12.dp),
                 modifier = modifier.fillMaxSize(),
             ) {
-                items(musicItems) { musicItem ->
+                items(musicItems, key = { it.id ?: it.name.hashCode() }) { musicItem ->
                     val coroutineScope = rememberCoroutineScope()
                     ExpressiveMusicCard(
                         item = musicItem,
@@ -540,7 +540,7 @@ private fun MusicContent(
                 verticalArrangement = Arrangement.spacedBy(12.dp),
                 modifier = modifier.fillMaxSize(),
             ) {
-                items(musicItems) { musicItem ->
+                items(musicItems, key = { it.id ?: it.name.hashCode() }) { musicItem ->
                     val coroutineScope = rememberCoroutineScope()
                     ExpressiveMusicCard(
                         item = musicItem,

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/OfflineScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/OfflineScreen.kt
@@ -294,7 +294,7 @@ private fun OfflineContentSection(
                 LazyColumn(
                     verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
-                    items(offlineContent) { item ->
+                    items(offlineContent, key = { it.id ?: it.name.hashCode() }) { item ->
                         OfflineContentItem(
                             item = item,
                             onPlay = { onPlayContent(item) },

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/TVEpisodesScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/TVEpisodesScreen.kt
@@ -288,7 +288,7 @@ private fun EpisodeList(
         contentPadding = PaddingValues(16.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
-        items(episodes) { episode ->
+        items(episodes, key = { it.id ?: it.name.hashCode() }) { episode ->
             ExpressiveEpisodeRow(
                 episode = episode,
                 getImageUrl = getImageUrl,

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/TVSeasonScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/TVSeasonScreen.kt
@@ -257,7 +257,7 @@ private fun TVSeasonContent(
                 )
             }
 
-            items(state.seasons) { season ->
+            items(state.seasons, key = { it.id ?: it.name.hashCode() }) { season ->
                 ExpressiveSeasonCard(
                     season = season,
                     getImageUrl = getImageUrl,
@@ -306,7 +306,7 @@ private fun TVSeasonContent(
                             horizontalArrangement = Arrangement.spacedBy(12.dp),
                             contentPadding = PaddingValues(horizontal = 4.dp),
                         ) {
-                            items(cast.take(10)) { person ->
+                            items(cast.take(10), key = { it.id ?: it.name.hashCode() }) { person ->
                                 PersonCard(
                                     person = person,
                                     getImageUrl = { id, tag ->
@@ -341,7 +341,7 @@ private fun TVSeasonContent(
                             horizontalArrangement = Arrangement.spacedBy(12.dp),
                             contentPadding = PaddingValues(horizontal = 4.dp),
                         ) {
-                            items(crew.take(8)) { person ->
+                            items(crew.take(8), key = { it.id ?: it.name.hashCode() }) { person ->
                                 PersonCard(
                                     person = person,
                                     getImageUrl = { id, tag ->

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/TVShowsScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/TVShowsScreen.kt
@@ -344,7 +344,7 @@ fun TVShowsScreen(
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                     contentPadding = PaddingValues(horizontal = 16.dp, vertical = 6.dp),
                 ) {
-                    items(TVShowFilter.getBasicFilters()) { filter ->
+                    items(TVShowFilter.getBasicFilters(), key = { it.name }) { filter ->
                         FilterChip(
                             onClick = { selectedFilter = filter },
                             label = {
@@ -379,7 +379,7 @@ fun TVShowsScreen(
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                     contentPadding = PaddingValues(horizontal = 16.dp, vertical = 6.dp),
                 ) {
-                    items(TVShowFilter.getSmartFilters()) { filter ->
+                    items(TVShowFilter.getSmartFilters(), key = { it.name }) { filter ->
                         FilterChip(
                             onClick = { selectedFilter = filter },
                             label = {


### PR DESCRIPTION
## Summary
- add stable keys to lazy list and grid items across media screens to improve stability

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939ff4293fc83278a2d2423a56ee127)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Enhanced stability of list rendering across multiple screens including album details, home screen, music library, video collection, and TV show browsing. This improves handling of dynamically updating content and reduces potential display inconsistencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->