### PR TITLE
Fix home videos pagination reset

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/HomeVideosScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/HomeVideosScreen.kt
@@ -42,6 +42,7 @@ import com.rpeters.jellyfin.ui.components.ExpressiveFullScreenLoading
 import com.rpeters.jellyfin.ui.components.ExpressiveMediaCard
 import com.rpeters.jellyfin.ui.components.ToolbarAction
 import com.rpeters.jellyfin.ui.viewmodel.MainAppViewModel
+import com.rpeters.jellyfin.utils.SecureLogger
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemKind
 
@@ -54,7 +55,7 @@ fun HomeVideosScreen(
     viewModel: MainAppViewModel = hiltViewModel(),
 ) {
     if (BuildConfig.DEBUG) {
-        android.util.Log.d("HomeVideosScreen", "HomeVideosScreen started")
+        SecureLogger.d("HomeVideosScreen", "HomeVideosScreen started")
     }
     val appState by viewModel.appState.collectAsState()
 
@@ -73,7 +74,10 @@ fun HomeVideosScreen(
                     val currentItems = appState.itemsByLibrary[libraryId.toString()] ?: emptyList()
                     if (currentItems.isEmpty()) {
                         if (BuildConfig.DEBUG) {
-                            android.util.Log.d("HomeVideosScreen", "Loading home videos for library: $libraryId")
+                            SecureLogger.d(
+                                "HomeVideosScreen",
+                                "Loading home videos for library: $libraryId",
+                            )
                         }
                         viewModel.loadHomeVideos(libraryId.toString())
                     }
@@ -90,10 +94,16 @@ fun HomeVideosScreen(
             library.id?.let { libraryId ->
                 val items = appState.itemsByLibrary[libraryId.toString()] ?: emptyList()
                 if (BuildConfig.DEBUG) {
-                    android.util.Log.d("HomeVideosScreen", "Found ${items.size} items in library: $libraryId")
+                    SecureLogger.d(
+                        "HomeVideosScreen",
+                        "Found ${items.size} items in library: $libraryId",
+                    )
                     if (items.isNotEmpty()) {
                         val typeBreakdown = items.groupBy { it.type?.name }.mapValues { it.value.size }
-                        android.util.Log.d("HomeVideosScreen", "Item types in library $libraryId: $typeBreakdown")
+                        SecureLogger.d(
+                            "HomeVideosScreen",
+                            "Item types in library $libraryId: $typeBreakdown",
+                        )
                     }
                 }
                 allItems.addAll(items)
@@ -114,7 +124,10 @@ fun HomeVideosScreen(
         }.sortedBy { it.sortName ?: it.name }
 
         if (BuildConfig.DEBUG) {
-            android.util.Log.d("HomeVideosScreen", "Total filtered home video items: ${filteredItems.size}")
+            SecureLogger.d(
+                "HomeVideosScreen",
+                "Total filtered home video items: ${filteredItems.size}",
+            )
         }
 
         filteredItems

--- a/app/src/main/java/com/rpeters/jellyfin/ui/viewmodel/MainAppViewModel.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/viewmodel/MainAppViewModel.kt
@@ -1127,15 +1127,25 @@ class MainAppViewModel @Inject constructor(
     }
 
     fun loadMoreHomeVideos(homeVideoLibraries: List<BaseItemDto>) {
-        homeVideoLibraries.forEach { library ->
-            val libraryId = library.id?.toString() ?: return@forEach
+        val libraryToLoad = homeVideoLibraries.firstOrNull { library ->
+            val libraryId = library.id?.toString()
+            if (libraryId == null) {
+                SecureLogger.w(
+                    "MainAppViewModel",
+                    "Skipping home video library with null ID: ${library.name ?: "Unknown"}",
+                )
+                return@firstOrNull false
+            }
+
             val paginationState = _appState.value.libraryPaginationState[libraryId]
-            val hasMore = paginationState?.hasMore ?: true
+            val hasMore = paginationState?.hasMore ?: false
             val isLoadingMore = paginationState?.isLoadingMore == true
 
-            if (hasMore && !isLoadingMore) {
-                loadMoreLibraryItems(libraryId)
-            }
+            hasMore && !isLoadingMore
+        }
+
+        libraryToLoad?.id?.toString()?.let { libraryId ->
+            loadMoreLibraryItems(libraryId)
         }
     }
 


### PR DESCRIPTION
## Summary
- derive pagination state from home video libraries to drive loading indicators
- load additional home videos per-library instead of reloading the entire initial data set
- keep scrolling position stable by avoiding full refresh when requesting more items

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69404820c1b08327997c9dd8431cdf3b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a load-more action for home videos that advances pagination across libraries when more items are available.

* **Refactor**
  * Improved pagination to track per-library loading and availability, making incremental loading more accurate and responsive.

* **Chores**
  * Replaced debug logging with a secure logger for startup and library loading diagnostics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->