### PR TITLE
fix: preserve stuff grid scroll position

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/StuffScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/StuffScreen.kt
@@ -236,7 +236,10 @@ fun StuffGrid(
         horizontalArrangement = Arrangement.spacedBy(12.dp),
         modifier = modifier,
     ) {
-        items(stuffItems) { stuffItem ->
+        items(
+            items = stuffItems,
+            key = { stuffItem -> stuffItem.id ?: stuffItem.name ?: stuffItem.sortName ?: stuffItem.hashCode() },
+        ) { stuffItem ->
             ExpressiveMediaCard(
                 title = stuffItem.name ?: "",
                 subtitle = stuffItem.type?.toString() ?: "",


### PR DESCRIPTION
## Summary
- add stable keys to the Stuff screen grid items to prevent scroll resets when pagination appends
- keep scroll position intact while loading more items in stuff libraries

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694307a60658832783986beda86b18c5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved stability of grid item rendering by implementing consistent item identification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->