### PR TITLE
fix: update Coil OkHttp fetcher usage

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/ui/image/OptimizedImageLoader.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/image/OptimizedImageLoader.kt
@@ -92,7 +92,7 @@ fun createOptimizedImageLoader(
         .components {
             add(
                 coil3.network.okhttp.OkHttpNetworkFetcherFactory(
-                    callFactory = { okHttpClient },
+                    callFactory = okHttpClient,
                 ),
             )
         }

--- a/app/src/main/java/com/rpeters/jellyfin/utils/ImageLoadingOptimizer.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/utils/ImageLoadingOptimizer.kt
@@ -81,7 +81,7 @@ object ImageLoadingOptimizer {
             .components {
                 add(
                     OkHttpNetworkFetcherFactory(
-                        callFactory = { imageHttpClient },
+                        callFactory = imageHttpClient,
                     ),
                 )
             }


### PR DESCRIPTION
### Motivation

- Migrate image loader configuration to match Coil 3.x API expectations and avoid runtime/compile issues.  
- Ensure the Coil network component receives the OkHttp call factory in the shape required by the updated `OkHttpNetworkFetcherFactory`.  
- Reduce the risk of image-loading regressions by aligning loader construction with the library's current API.  

### Description

- Updated `callFactory` usage in `app/src/main/java/com/rpeters/jellyfin/ui/image/OptimizedImageLoader.kt` to pass the `OkHttpClient` directly via `callFactory = okHttpClient`.  
- Updated `callFactory` usage in `app/src/main/java/com/rpeters/jellyfin/utils/ImageLoadingOptimizer.kt` to pass the built `imageHttpClient` directly via `callFactory = imageHttpClient`.  
- Left existing memory and disk cache builders intact while aligning the network fetcher configuration with Coil 3.x.  

### Testing

- Ran `./gradlew testDebugUnitTest` which failed to run due to missing Android SDK location (`SDK location not found`).  
- Ran `./gradlew connectedAndroidTest` which also failed due to the same SDK/local properties issue.  
- Static searches (`rg`) were used to locate Coil-related usages to ensure the two updated sites covered the relevant code paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694980f58b088327b70eb5a941321b82)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal optimization of HTTP client initialization logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->