### PR TITLE
fix: read pager state directly for indicators

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/ui/components/ExpressiveCarousel.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/components/ExpressiveCarousel.kt
@@ -4,7 +4,6 @@ package com.rpeters.jellyfin.ui.components
 
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -43,10 +42,10 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.rpeters.jellyfin.OptInAppExperimentalApis
 import com.rpeters.jellyfin.ui.image.ImageSize
 import com.rpeters.jellyfin.ui.image.OptimizedImage
 import com.rpeters.jellyfin.ui.theme.MotionTokens
-import com.rpeters.jellyfin.OptInAppExperimentalApis
 
 /**
  * Material 3 Expressive Carousel for hero content


### PR DESCRIPTION
### Motivation
- Remove a redundant derived local `currentPage` state used by the carousel indicators to prevent stale values during pager scroll.
- Ensure indicator UI observes `PagerState` directly so the active indicator updates immediately when the pager changes.
- Simplify the `ExpressiveCarousel` code to reduce recomposition/state mismatch risk.

### Description
- Updated `ExpressiveCarouselIndicators` in `app/src/main/java/com/rpeters/jellyfin/ui/components/ExpressiveCarousel.kt` to remove the local `currentPage` variable and compute `isActive` using `pagerState.currentPage` directly.
- Indicator sizing and color behavior remain unchanged; only the source of truth for the active page was switched to `PagerState`.

### Testing
- No automated tests were executed as part of this change.
- It is recommended to run `./gradlew testDebugUnitTest` and `./gradlew lintDebug` before requesting review to validate unit tests and linting.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949810287ac8327a286fcc78afe5a1d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved carousel indicator rendering by eliminating intermediate state variables in favor of direct state references, resulting in cleaner and more maintainable code.
  * Updated import organization to align with the codebase's established API opt-in patterns, ensuring consistency and standardization without any changes to component behavior or user interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->