### PR TITLE
fix: use R.string.unknown instead of hardcoded "Unknown"

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/data/offline/OfflineDownloadManager.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/data/offline/OfflineDownloadManager.kt
@@ -9,6 +9,7 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.rpeters.jellyfin.BuildConfig
+import com.rpeters.jellyfin.R
 import com.rpeters.jellyfin.data.repository.JellyfinRepository
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.*
@@ -250,7 +251,7 @@ class OfflineDownloadManager @Inject constructor(
 
         return OfflineDownload(
             jellyfinItemId = item.id.toString(),
-            itemName = item.name ?: "Unknown",
+            itemName = item.name ?: context.getString(R.string.unknown),
             itemType = item.type?.toString() ?: "Video",
             downloadUrl = url,
             localFilePath = localPath,

--- a/app/src/main/java/com/rpeters/jellyfin/ui/components/tv/TvContentCarousel.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/components/tv/TvContentCarousel.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -32,6 +33,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import coil3.compose.AsyncImage
 import coil3.request.ImageRequest
 import coil3.request.crossfade
+import com.rpeters.jellyfin.R
 import com.rpeters.jellyfin.ui.adaptive.AdaptiveLayoutConfig
 import com.rpeters.jellyfin.ui.tv.TvFocusManager
 import com.rpeters.jellyfin.ui.tv.TvFocusableCarousel
@@ -174,7 +176,7 @@ fun TvContentCard(
 
         // Title below the card
         TvText(
-            text = item.name ?: "Unknown",
+            text = item.name ?: stringResource(id = R.string.unknown),
             style = TvMaterialTheme.typography.titleMedium,
             maxLines = 2,
             overflow = TextOverflow.Ellipsis,

--- a/app/src/main/java/com/rpeters/jellyfin/ui/player/TrackSelectionManager.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/player/TrackSelectionManager.kt
@@ -1,5 +1,6 @@
 package com.rpeters.jellyfin.ui.player
 
+import android.content.Context
 import android.util.Log
 import androidx.media3.common.C
 import androidx.media3.common.Format
@@ -7,6 +8,7 @@ import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
 import com.rpeters.jellyfin.BuildConfig
+import com.rpeters.jellyfin.R
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -38,12 +40,14 @@ data class TrackSelectionState(
 
 @UnstableApi
 class TrackSelectionManager(
+    private val context: Context,
     private val exoPlayer: ExoPlayer,
     private val trackSelector: DefaultTrackSelector,
 ) {
 
     private val _trackSelectionState = MutableStateFlow(TrackSelectionState())
     val trackSelectionState: StateFlow<TrackSelectionState> = _trackSelectionState.asStateFlow()
+    private val unknownLabel = context.getString(R.string.unknown)
 
     fun updateAvailableTracks() {
         val currentTracks = exoPlayer.currentTracks
@@ -211,7 +215,7 @@ class TrackSelectionManager(
     }
 
     private fun buildAudioTrackLabel(format: Format): String {
-        val language = format.language?.let { getLanguageDisplayName(it) } ?: "Unknown"
+        val language = format.language?.let { getLanguageDisplayName(it) } ?: unknownLabel
         val channels = when (format.channelCount) {
             1 -> "Mono"
             2 -> "Stereo"
@@ -237,7 +241,7 @@ class TrackSelectionManager(
     }
 
     private fun buildSubtitleTrackLabel(format: Format): String {
-        val language = format.language?.let { getLanguageDisplayName(it) } ?: "Unknown"
+        val language = format.language?.let { getLanguageDisplayName(it) } ?: unknownLabel
         val forced = if ((format.selectionFlags and C.SELECTION_FLAG_FORCED) != 0) " (Forced)" else ""
         return "$language$forced"
     }

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/HomeScreen.kt
@@ -424,7 +424,7 @@ fun HomeContent(
                     val featured = remember(contentLists.featuredItems) {
                         contentLists.featuredItems.map {
                             it.toCarouselItem(
-                                titleOverride = it.name ?: "Unknown",
+                                titleOverride = it.name ?: stringResource(id = R.string.unknown),
                                 subtitleOverride = itemSubtitle(it),
                                 imageUrl = getBackdropUrl(it) ?: getSeriesImageUrl(it)
                                     ?: getImageUrl(it) ?: "",
@@ -891,7 +891,7 @@ private fun ContinueWatchingCard(
                 verticalArrangement = Arrangement.spacedBy(4.dp),
             ) {
                 Text(
-                    text = item.name ?: "Unknown",
+                    text = item.name ?: stringResource(id = R.string.unknown),
                     style = MaterialTheme.typography.labelLarge,
                     fontWeight = FontWeight.SemiBold,
                     maxLines = 2,

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/LibraryItemCard.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/LibraryItemCard.kt
@@ -24,10 +24,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import coil3.compose.SubcomposeAsyncImage
 import com.rpeters.jellyfin.OptInAppExperimentalApis
+import com.rpeters.jellyfin.R
 import com.rpeters.jellyfin.ui.ShimmerBox
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemKind
@@ -136,7 +138,7 @@ fun LibraryItemCard(
 
                 Column(modifier = Modifier.padding(LibraryScreenDefaults.CompactCardPadding)) {
                     Text(
-                        text = item.name ?: "Unknown",
+                        text = item.name ?: stringResource(id = R.string.unknown),
                         style = MaterialTheme.typography.titleMedium,
                         fontWeight = FontWeight.SemiBold,
                         maxLines = 2,
@@ -209,7 +211,7 @@ fun LibraryItemCard(
                     verticalArrangement = Arrangement.spacedBy(LibraryScreenDefaults.ListItemFavoriteIconPadding),
                 ) {
                     Text(
-                        text = item.name ?: "Unknown",
+                        text = item.name ?: stringResource(id = R.string.unknown),
                         style = MaterialTheme.typography.titleLarge,
                         fontWeight = FontWeight.Bold,
                         maxLines = 2,

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/MovieDetailScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/MovieDetailScreen.kt
@@ -315,7 +315,7 @@ fun MovieDetailScreen(
                                 )
 
                                 ExpressiveMediaCard(
-                                    title = relatedMovie.name ?: "Unknown",
+                                    title = relatedMovie.name ?: stringResource(id = R.string.unknown),
                                     subtitle = relatedMovie.productionYear?.toString() ?: "",
                                     imageUrl = getImageUrl(relatedMovie) ?: "",
                                     rating = relatedMovie.communityRating?.toFloat(),
@@ -630,7 +630,7 @@ private fun ExpressiveMovieInfoCard(
                 movie.mediaSources?.firstOrNull()?.mediaStreams?.let { streams ->
                     val videoStream = streams.firstOrNull { it.type == MediaStreamType.VIDEO }
                     val audioStream = streams.firstOrNull { it.type == MediaStreamType.AUDIO }
-                    val resolution = getMovieResolution(videoStream)
+                    val resolution = getMovieResolution(videoStream, stringResource(id = R.string.unknown))
 
                     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                         videoStream?.let { stream ->
@@ -725,9 +725,12 @@ private fun ExpressiveInfoRow(
 }
 
 // Helper function for movie resolution detection
-private fun getMovieResolution(videoStream: org.jellyfin.sdk.model.api.MediaStream?): String {
+private fun getMovieResolution(
+    videoStream: org.jellyfin.sdk.model.api.MediaStream?,
+    unknownLabel: String,
+): String {
     return when (videoStream?.height) {
-        null -> "Unknown"
+        null -> unknownLabel
         in 1..719 -> "SD"
         720 -> "720p"
         in 721..1079 -> "HD"

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/OfflineScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/OfflineScreen.kt
@@ -11,9 +11,11 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.rpeters.jellyfin.R
 import com.rpeters.jellyfin.ui.utils.*
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemKind
@@ -345,7 +347,7 @@ private fun OfflineContentItem(
 
                 Column {
                     Text(
-                        text = item.name ?: "Unknown",
+                        text = item.name ?: stringResource(id = R.string.unknown),
                         style = MaterialTheme.typography.bodyMedium,
                     )
 

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/ProfileScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/ProfileScreen.kt
@@ -155,7 +155,7 @@ fun ProfileScreen(
                     currentServer?.let { server ->
                         ProfileInfoRow("Server Name", server.name)
                         ProfileInfoRow("Server URL", server.url)
-                        ProfileInfoRow("User ID", server.userId ?: "Unknown")
+                        ProfileInfoRow("User ID", server.userId ?: stringResource(id = R.string.unknown))
                     }
                 }
             }

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/TVSeasonScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/TVSeasonScreen.kt
@@ -834,7 +834,7 @@ private fun PersonCard(
             }
 
             Text(
-                text = person.name ?: "Unknown",
+                text = person.name ?: stringResource(id = R.string.unknown),
                 style = MaterialTheme.typography.bodySmall,
                 fontWeight = FontWeight.Medium,
                 maxLines = 2,

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/TVShowsScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/TVShowsScreen.kt
@@ -614,7 +614,7 @@ private fun TVShowsContent(
                         )
 
                         ExpressiveCompactCard(
-                            title = tvShow.name ?: "Unknown",
+                            title = tvShow.name ?: stringResource(id = R.string.unknown),
                             subtitle = buildString {
                                 tvShow.productionYear?.let { append("$it • ") }
                                 tvShow.childCount?.let { append("$it episodes") }
@@ -650,7 +650,7 @@ private fun TVShowsContent(
                     tvShows.take(20).map { tvShow ->
                         CarouselItem(
                             id = tvShow.id.toString(),
-                            title = tvShow.name ?: "Unknown",
+                            title = tvShow.name ?: stringResource(id = R.string.unknown),
                             subtitle = tvShow.productionYear?.toString() ?: "",
                             imageUrl = getImageUrl(tvShow) ?: "",
                             type = MediaType.TV_SHOW,

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/tv/adaptive/TvAdaptiveHomeContent.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/tv/adaptive/TvAdaptiveHomeContent.kt
@@ -23,7 +23,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
+import com.rpeters.jellyfin.R
 import com.rpeters.jellyfin.ui.adaptive.AdaptiveLayoutConfig
 import com.rpeters.jellyfin.ui.components.tv.TvContentCard
 import com.rpeters.jellyfin.ui.components.tv.TvContentCarousel
@@ -300,7 +302,7 @@ private fun RowScope.TabletDetailPane(
         }
 
         TvText(
-            text = item.name ?: "Unknown",
+            text = item.name ?: stringResource(id = R.string.unknown),
             style = TvMaterialTheme.typography.headlineMedium,
             color = TvMaterialTheme.colorScheme.onSurface,
             maxLines = 2,

--- a/app/src/main/java/com/rpeters/jellyfin/ui/utils/DownloadManager.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/utils/DownloadManager.kt
@@ -13,6 +13,7 @@ import android.util.Log
 import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
 import com.rpeters.jellyfin.BuildConfig
+import com.rpeters.jellyfin.R
 import com.rpeters.jellyfin.data.storage.MediaStoreSaver
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemKind
@@ -45,15 +46,16 @@ object MediaDownloadManager {
                 return null
             }
 
+            val unknownLabel = context.getString(R.string.unknown)
             val downloadManager = context.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
 
             // Create download request
             val request = DownloadManager.Request(streamUrl.toUri()).apply {
-                setTitle("${item.name ?: "Unknown"}")
+                setTitle("${item.name ?: unknownLabel}")
                 setDescription("Downloading from Jellyfin")
 
                 // Set destination in Downloads directory with organized folder structure
-                val fileName = generateFileName(item)
+                val fileName = generateFileName(item, unknownLabel)
                 val subPath = generateSubPath(item)
                 val mimeType = getMimeType(item) ?: DEFAULT_MIME_TYPE
                 queryDownloadEntry(context, fileName, subPath)?.uri?.let { existingUri ->
@@ -102,7 +104,7 @@ object MediaDownloadManager {
                 Log.w(TAG, "Missing storage permission for ${item.name}")
                 return false
             }
-            val fileName = generateFileName(item)
+            val fileName = generateFileName(item, context.getString(R.string.unknown))
             val subPath = generateSubPath(item)
 
             queryDownloadEntry(context, fileName, subPath) != null
@@ -125,7 +127,7 @@ object MediaDownloadManager {
                 Log.w(TAG, "Missing storage permission for ${item.name}")
                 return null
             }
-            val fileName = generateFileName(item)
+            val fileName = generateFileName(item, context.getString(R.string.unknown))
             val subPath = generateSubPath(item)
 
             queryDownloadEntry(context, fileName, subPath)?.uri?.toString()
@@ -148,7 +150,7 @@ object MediaDownloadManager {
                 Log.w(TAG, "Missing storage permission for ${item.name}")
                 return false
             }
-            val fileName = generateFileName(item)
+            val fileName = generateFileName(item, context.getString(R.string.unknown))
             val subPath = generateSubPath(item)
 
             val entry = queryDownloadEntry(context, fileName, subPath)
@@ -300,8 +302,8 @@ object MediaDownloadManager {
         }
     }
 
-    private fun generateFileName(item: BaseItemDto): String {
-        val baseName = (item.name ?: "Unknown").replace(Regex("[^a-zA-Z0-9._-]"), "_")
+    private fun generateFileName(item: BaseItemDto, unknownLabel: String): String {
+        val baseName = (item.name ?: unknownLabel).replace(Regex("[^a-zA-Z0-9._-]"), "_")
         val extension = getFileExtension(item)
         return "$baseName.$extension"
     }

--- a/app/src/main/java/com/rpeters/jellyfin/ui/utils/EnhancedPlaybackUtils.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/utils/EnhancedPlaybackUtils.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.util.Log
 import com.rpeters.jellyfin.BuildConfig
+import com.rpeters.jellyfin.R
 import com.rpeters.jellyfin.data.playback.EnhancedPlaybackManager
 import com.rpeters.jellyfin.data.playback.PlaybackResult
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -139,6 +140,7 @@ class EnhancedPlaybackUtils @Inject constructor(
         return withContext(Dispatchers.IO) {
             try {
                 val playbackResult = enhancedPlaybackManager.getOptimalPlaybackUrl(item)
+                val unknownLabel = context.getString(R.string.unknown)
 
                 when (playbackResult) {
                     is PlaybackResult.DirectPlay -> {
@@ -169,7 +171,7 @@ class EnhancedPlaybackUtils @Inject constructor(
                         PlaybackCapabilityAnalysis(
                             canPlay = false,
                             preferredMethod = PlaybackMethod.UNAVAILABLE,
-                            expectedQuality = "Unknown",
+                            expectedQuality = unknownLabel,
                             details = "Error: ${playbackResult.message}",
                             codecs = "N/A",
                             container = "N/A",
@@ -179,10 +181,11 @@ class EnhancedPlaybackUtils @Inject constructor(
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to analyze playback capabilities", e)
+                val unknownLabel = context.getString(R.string.unknown)
                 PlaybackCapabilityAnalysis(
                     canPlay = false,
                     preferredMethod = PlaybackMethod.UNAVAILABLE,
-                    expectedQuality = "Unknown",
+                    expectedQuality = unknownLabel,
                     details = "Analysis failed: ${e.message}",
                     codecs = "N/A",
                     container = "N/A",

--- a/app/src/main/java/com/rpeters/jellyfin/ui/viewmodel/MainAppViewModel.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/viewmodel/MainAppViewModel.kt
@@ -1,9 +1,11 @@
 package com.rpeters.jellyfin.ui.viewmodel
 
+import android.content.Context
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.media3.common.util.UnstableApi
+import com.rpeters.jellyfin.R
 import com.rpeters.jellyfin.data.SecureCredentialManager
 import com.rpeters.jellyfin.data.repository.JellyfinAuthRepository
 import com.rpeters.jellyfin.data.repository.JellyfinMediaRepository
@@ -17,6 +19,7 @@ import com.rpeters.jellyfin.ui.screens.LibraryType
 import com.rpeters.jellyfin.utils.SecureLogger
 import com.rpeters.jellyfin.utils.isWatched
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -95,6 +98,7 @@ data class LibraryPaginationState(
 @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class MainAppViewModel @Inject constructor(
+    @ApplicationContext private val context: Context,
     private val repository: JellyfinRepository,
     private val authRepository: JellyfinAuthRepository,
     private val mediaRepository: JellyfinMediaRepository,
@@ -1142,7 +1146,7 @@ class MainAppViewModel @Inject constructor(
             if (libraryId == null) {
                 SecureLogger.w(
                     "MainAppViewModel",
-                    "Skipping home video library with null ID: ${library.name ?: "Unknown"}",
+                    "Skipping home video library with null ID: ${library.name ?: context.getString(R.string.unknown)}",
                 )
                 return@firstOrNull false
             }

--- a/app/src/main/java/com/rpeters/jellyfin/utils/NetworkDebugger.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/utils/NetworkDebugger.kt
@@ -7,6 +7,7 @@ import android.net.TrafficStats
 import android.os.Process
 import android.util.Log
 import com.rpeters.jellyfin.BuildConfig
+import com.rpeters.jellyfin.R
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
@@ -42,7 +43,7 @@ object NetworkDebugger {
         if (capabilities == null) {
             return NetworkStatus(
                 isConnected = false,
-                connectionType = "Unknown",
+                connectionType = context.getString(R.string.unknown),
                 isMetered = false,
                 hasInternet = false,
                 details = "No network capabilities",


### PR DESCRIPTION
### Motivation
- Replace scattered hardcoded "Unknown" literals with a single localized resource to ensure consistent UI localization.
- Avoid mixing string literals in UI and utility layers so labels are consistent across Compose, TV and non-Compose code.
- Thread a shared unknown label into helper functions so generated filenames, playback analysis, and debug output use the same localized text.

### Description
- Replaced occurrences of the literal `"Unknown"` across multiple Compose and TV components with `stringResource(id = R.string.unknown)` or `context.getString(R.string.unknown)` where appropriate (examples: `HomeScreen`, `TVShowsScreen`, `TVSeasonScreen`, `MovieDetailScreen`, `ProfileScreen`, `OfflineScreen`, `TvAdaptiveHomeContent`, `LibraryItemCard`, `TvContentCarousel`).
- Updated utility/manager classes to use the localized unknown label including `OfflineDownloadManager`, `MediaDownloadManager` (changed `generateFileName` signature to accept `unknownLabel`), `EnhancedPlaybackUtils`, and `NetworkDebugger`.
- Threaded the unknown label into helper methods and track/label builders (e.g., `getMovieResolution(...)`, `generateFileName(...)`, `TrackSelectionManager`) and added necessary `R`/`stringResource` imports.
- Small refactors to pull an `unknownLabel` from `context` or Compose `stringResource` to centralize the replacement and keep behavior identical when the item name is missing.

### Testing
- No automated tests were executed as part of this change.
- Please run `./gradlew testDebugUnitTest` and `./gradlew lintDebug` (and optionally `./gradlew connectedAndroidTest`) before requesting review to validate unit tests and linting.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694990799e348327a2933840d74d85b2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced localization: Improved multilingual support by displaying localized fallback text throughout the app when item information is unavailable, now respecting your device's language settings across all screens and features.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->