### PR TITLE
docs: remove resolved Kotlin compiler warning

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -82,45 +82,13 @@ However, `PullToRefreshBox` is imported from `androidx.compose.material3.pulltor
 
 ---
 
-### 3. Kotlin Compiler Flag Warning
-
-**Status**: Build warning
-**Severity**: Low
-**Impact**: Cosmetic build warning, no functional impact
-
-**Description**:
-Build shows warning:
-```
-w: Flag is not supported by this version of the compiler: -Xannotation-default-target=param-property
-```
-
-**Cause**:
-This compiler flag was added in Kotlin 2.2.x, but project uses Kotlin 2.1.0 for Hilt compatibility.
-
-**Current Behavior**:
-- Warning appears during build
-- No impact on functionality
-- Build succeeds
-
-**Workaround**:
-Remove the flag from `app/build.gradle.kts` or wait for Kotlin/Hilt version compatibility.
-
-**Next Steps**:
-- [ ] Remove unsupported flag from build config
-- [ ] OR upgrade to Kotlin 2.2+ when Hilt supports it
-
-**Related Files**:
-- `app/build.gradle.kts` (line 54-60)
-
----
-
 ## 🔧 Medium Priority Issues
 
-### 4. Incomplete Feature Implementations
+### 3. Incomplete Feature Implementations
 
 Several features have UI components but incomplete functionality:
 
-#### 4.1 Music Playback Controls
+#### 3.1 Music Playback Controls
 
 **Status**: Partially implemented
 **Severity**: Medium
@@ -141,7 +109,7 @@ Several features have UI components but incomplete functionality:
 
 ---
 
-#### 4.2 Offline Downloads
+#### 3.2 Offline Downloads
 
 **Status**: Partially implemented
 **Severity**: Medium
@@ -163,7 +131,7 @@ Several features have UI components but incomplete functionality:
 
 ---
 
-#### 4.3 Android TV Support
+#### 3.3 Android TV Support
 
 **Status**: Partially implemented
 **Severity**: Medium
@@ -184,7 +152,7 @@ Several features have UI components but incomplete functionality:
 
 ---
 
-### 5. Experimental Coroutines API Usage
+### 4. Experimental Coroutines API Usage
 
 **Status**: Build warnings
 **Severity**: Low


### PR DESCRIPTION
### Motivation
- Reconcile `KNOWN_ISSUES.md` with the project's actual Kotlin version and build configuration.
- The project declares Kotlin `2.3.0` in `gradle/libs.versions.toml`, which supports the `-Xannotation-default-target=param-property` compiler flag.
- The previously-documented build warning about the unsupported compiler flag is therefore obsolete and may confuse contributors.
- Keep the known-issues documentation accurate to reduce noise during development.

### Description
- Removed the "Kotlin Compiler Flag Warning" section from `KNOWN_ISSUES.md`.
- Renumbered subsequent issue headings so sections remain sequential.
- Confirmed the compiler flag `-Xannotation-default-target=param-property` remains in `app/build.gradle.kts` and Kotlin version is `2.3.0` in `gradle/libs.versions.toml`.
- This change is documentation-only and modifies only `KNOWN_ISSUES.md`.

### Testing
- No automated tests were run because this is a documentation-only change.
- `./gradlew testDebugUnitTest` and `./gradlew lintDebug` were not executed as part of this update.
- There were no code changes that would affect the build or runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ad26dd6848327997cee10aeb12b09)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated and reorganized the Known Issues documentation with revised section numbering.
  * Removed a previously documented issue from the known issues list.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->