### PR TITLE
fix: load episode details when navigating to TV episode detail

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/ui/navigation/DetailNavGraph.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/navigation/DetailNavGraph.kt
@@ -298,7 +298,10 @@ fun androidx.navigation.NavGraphBuilder.detailNavGraph(
             appState.allItems.find { it.id == seasonId }
         }
 
-        LaunchedEffect(episode) {
+        LaunchedEffect(episodeId, episode) {
+            if (episode == null) {
+                mainViewModel.loadEpisodeDetails(episodeId)
+            }
             episode?.let { viewModel.loadEpisodeAnalysis(it) }
         }
 


### PR DESCRIPTION
### Motivation
- Navigating from a season/episode list to the TV episode detail screen could leave the detail view stuck loading because the episode object was not present in `appState`.
- The app needs to fetch missing episode details when entering the detail route so the screen can render immediately once data arrives.
- Avoid triggering duplicate network fetches by reusing the same effect that runs playback analysis.

### Description
- Updated `app/src/main/java/com/rpeters/jellyfin/ui/navigation/DetailNavGraph.kt` to change the `LaunchedEffect` to depend on `episodeId` and `episode`.
- When `episode == null` the nav graph now calls `mainViewModel.loadEpisodeDetails(episodeId)` to fetch and add the episode to `appState`.
- Kept the call to `viewModel.loadEpisodeAnalysis(it)` within the same `LaunchedEffect` so analysis still runs when the episode becomes available.

### Testing
- No automated tests were run for this change.
- Please run `./gradlew testDebugUnitTest` and `./gradlew lintDebug` locally before requesting review to verify unit tests and linting pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694adf6857d08327854a342a3a037985)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed TV episode detail loading to ensure episode information is properly retrieved when navigating to episodes. The system now correctly fetches complete episode data during navigation transitions, preventing potential issues with missing or stale content displays.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->