### PR TITLE
fix: reduce TV shows header text size

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/TVShowsScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/TVShowsScreen.kt
@@ -64,6 +64,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -252,11 +253,13 @@ fun TVShowsScreen(
                         color = MaterialTheme.colorScheme.primaryContainer,
                     ) {
                         Text(
-                            text = "TV Shows",
-                            style = MaterialTheme.typography.headlineSmall,
-                            fontWeight = FontWeight.Bold,
+                            text = stringResource(id = R.string.tv_shows),
+                            style = MaterialTheme.typography.titleLarge,
+                            fontWeight = FontWeight.SemiBold,
                             color = MaterialTheme.colorScheme.onPrimaryContainer,
-                            modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp),
                         )
                     }
                 },


### PR DESCRIPTION
## Summary
- use a smaller title style for the TV Shows top app bar and source text from string resources
- add single-line/ellipsis handling with tighter padding to prevent the title from overpowering the controls

## Testing
- Not run (UI-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69521711aee08327a701bb13fde5cffb)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced TV Shows header with localization support for improved multi-language compatibility.
  * Refined header typography styling and adjusted spacing for better visual consistency.
  * Improved text handling with truncation to prevent content overflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->