### PR TITLE
Add offline manager and screen tests

### DIFF
--- a/app/src/androidTest/java/com/rpeters/jellyfin/ui/screens/OfflineScreenTest.kt
+++ b/app/src/androidTest/java/com/rpeters/jellyfin/ui/screens/OfflineScreenTest.kt
@@ -19,13 +19,13 @@ import com.rpeters.jellyfin.ui.utils.OfflineStorageInfo
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import java.util.UUID
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemKind
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.util.UUID
 
 @RunWith(AndroidJUnit4::class)
 class OfflineScreenTest {

--- a/app/src/test/java/com/rpeters/jellyfin/ui/utils/OfflineManagerTest.kt
+++ b/app/src/test/java/com/rpeters/jellyfin/ui/utils/OfflineManagerTest.kt
@@ -13,6 +13,10 @@ import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.slot
 import io.mockk.unmockkAll
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.jellyfin.sdk.model.api.BaseItemDto
+import org.jellyfin.sdk.model.api.BaseItemKind
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -20,10 +24,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.test.runTest
-import org.jellyfin.sdk.model.api.BaseItemDto
-import org.jellyfin.sdk.model.api.BaseItemKind
 
 class OfflineManagerTest {
 


### PR DESCRIPTION
## Summary
- add OfflineManager unit coverage for connectivity state, storage info, and playback selection helpers
- add OfflineScreen UI tests for empty/downloaded lists, clear-all dialog visibility, and play/delete actions

## Testing
- ./gradlew testDebugUnitTest *(fails: Android SDK not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952b074385883278437273b71f454c4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for offline screen rendering in various states.
  * Added test coverage for offline storage management, network transitions, and content playback.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->