### PR TITLE
Fix CI workflow indentation and polish Compose UI

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -50,19 +50,19 @@ jobs:
           chmod +x scripts/gen-local-properties.sh || true
           ./scripts/gen-local-properties.sh
     
-    - name: Build with Gradle
-      run: ./gradlew assembleDebug --stacktrace
-      
-    - name: Run checks
-      run: ./gradlew lintDebug testDebugUnitTest
+      - name: Build with Gradle
+        run: ./gradlew assembleDebug --stacktrace
+        
+      - name: Run checks
+        run: ./gradlew lintDebug testDebugUnitTest
 
-    - name: Generate coverage
-      run: ./gradlew jacocoTestReport
+      - name: Generate coverage
+        run: ./gradlew jacocoTestReport
 
-    - name: Upload reports
-      uses: actions/upload-artifact@v4
-      with:
-        name: reports
-        path: |
-          app/build/reports
-          app/build/jacoco
+      - name: Upload reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: reports
+          path: |
+            app/build/reports
+            app/build/jacoco

--- a/app/src/main/java/com/rpeters/jellyfin/ui/components/ExpressiveCarousel.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/components/ExpressiveCarousel.kt
@@ -204,7 +204,7 @@ private fun ExpressiveHeroCard(
                     text = item.title,
                     style = MaterialTheme.typography.headlineMedium,
                     fontWeight = FontWeight.Bold,
-                    color = Color.White,
+                    color = MaterialTheme.colorScheme.onSurface,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
                 )
@@ -213,7 +213,7 @@ private fun ExpressiveHeroCard(
                     Text(
                         text = item.subtitle,
                         style = MaterialTheme.typography.bodyLarge,
-                        color = Color.White.copy(alpha = 0.9f),
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.9f),
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                         modifier = Modifier.padding(top = 4.dp),

--- a/app/src/main/java/com/rpeters/jellyfin/ui/components/PlaybackRecommendationNotifications.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/components/PlaybackRecommendationNotifications.kt
@@ -15,7 +15,6 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.rpeters.jellyfin.ui.utils.PlaybackRecommendation
@@ -37,7 +36,10 @@ fun PlaybackRecommendationNotification(
         verticalArrangement = Arrangement.spacedBy(8.dp),
         contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
     ) {
-        itemsIndexed(recommendations) { index, recommendation ->
+        itemsIndexed(
+            items = recommendations,
+            key = { index, recommendation -> "${recommendation.type}-${recommendation.message}-$index" },
+        ) { index, recommendation ->
             PlaybackRecommendationCard(
                 recommendation = recommendation,
                 onDismiss = { onDismiss(recommendation) },
@@ -76,8 +78,8 @@ fun PlaybackRecommendationCard(
     ) {
         val (backgroundColor, textColor, icon) = when (recommendation.type) {
             RecommendationType.OPTIMAL -> Triple(
-                Color(0xFF4CAF50),
-                Color.White,
+                MaterialTheme.colorScheme.tertiaryContainer,
+                MaterialTheme.colorScheme.onTertiaryContainer,
                 Icons.Filled.CheckCircle,
             )
             RecommendationType.INFO -> Triple(
@@ -86,8 +88,8 @@ fun PlaybackRecommendationCard(
                 Icons.Filled.Info,
             )
             RecommendationType.WARNING -> Triple(
-                Color(0xFFFF9800),
-                Color.White,
+                MaterialTheme.colorScheme.secondaryContainer,
+                MaterialTheme.colorScheme.onSecondaryContainer,
                 Icons.Filled.Warning,
             )
             RecommendationType.ERROR -> Triple(
@@ -246,10 +248,22 @@ fun InContextPlaybackRecommendation(
     modifier: Modifier = Modifier,
 ) {
     val (borderColor, backgroundColor) = when (recommendation.type) {
-        RecommendationType.OPTIMAL -> Pair(Color(0xFF4CAF50), Color(0xFF4CAF50).copy(alpha = 0.1f))
-        RecommendationType.INFO -> Pair(MaterialTheme.colorScheme.primary, MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f))
-        RecommendationType.WARNING -> Pair(Color(0xFFFF9800), Color(0xFFFF9800).copy(alpha = 0.1f))
-        RecommendationType.ERROR -> Pair(MaterialTheme.colorScheme.error, MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.3f))
+        RecommendationType.OPTIMAL -> Pair(
+            MaterialTheme.colorScheme.tertiary,
+            MaterialTheme.colorScheme.tertiaryContainer,
+        )
+        RecommendationType.INFO -> Pair(
+            MaterialTheme.colorScheme.primary,
+            MaterialTheme.colorScheme.primaryContainer,
+        )
+        RecommendationType.WARNING -> Pair(
+            MaterialTheme.colorScheme.secondary,
+            MaterialTheme.colorScheme.secondaryContainer,
+        )
+        RecommendationType.ERROR -> Pair(
+            MaterialTheme.colorScheme.error,
+            MaterialTheme.colorScheme.errorContainer,
+        )
     }
 
     Card(

--- a/app/src/main/java/com/rpeters/jellyfin/ui/player/tv/TvAudioQueueDisplay.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/player/tv/TvAudioQueueDisplay.kt
@@ -40,7 +40,6 @@ import androidx.compose.ui.draw.scale
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
@@ -94,7 +93,7 @@ fun TvAudioQueueDisplay(
     Box(
         modifier = modifier
             .fillMaxSize()
-            .background(Color.Black.copy(alpha = 0.85f))
+            .background(MaterialTheme.colorScheme.scrim.copy(alpha = 0.85f))
             .onKeyEvent { keyEvent ->
                 if (keyEvent.type == KeyEventType.KeyDown && keyEvent.key == Key.Back) {
                     onDismiss()
@@ -220,7 +219,10 @@ fun TvAudioQueueDisplay(
                         verticalArrangement = Arrangement.spacedBy(12.dp),
                         contentPadding = PaddingValues(vertical = 8.dp),
                     ) {
-                        itemsIndexed(queue) { index, mediaItem ->
+                        itemsIndexed(
+                            items = queue,
+                            key = { index, mediaItem -> mediaItem.mediaId.ifEmpty { index.toString() } },
+                        ) { index, mediaItem ->
                             QueueTrackItem(
                                 mediaItem = mediaItem,
                                 isCurrentTrack = index == currentIndex,

--- a/app/src/main/java/com/rpeters/jellyfin/ui/player/tv/TvVideoPlayerScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/player/tv/TvVideoPlayerScreen.kt
@@ -199,7 +199,7 @@ fun TvVideoPlayerScreen(
     Box(
         modifier = modifier
             .fillMaxSize()
-            .background(Color.Black)
+            .background(MaterialTheme.colorScheme.background)
             .tvKeyboardHandler(
                 focusManager = focusManager,
                 onBack = {
@@ -268,8 +268,8 @@ fun TvVideoPlayerScreen(
                     .background(
                         Brush.verticalGradient(
                             colors = listOf(
-                                Color.Black.copy(alpha = 0.75f),
-                                Color.Black.copy(alpha = 0.35f),
+                                MaterialTheme.colorScheme.scrim.copy(alpha = 0.75f),
+                                MaterialTheme.colorScheme.scrim.copy(alpha = 0.35f),
                                 Color.Transparent,
                             ),
                         ),
@@ -292,7 +292,7 @@ fun TvVideoPlayerScreen(
                         Text(
                             text = formatPlaybackPosition(state.currentPosition, state.duration),
                             style = MaterialTheme.typography.titleMedium,
-                            color = Color.White.copy(alpha = 0.85f),
+                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.85f),
                         )
                     }
 
@@ -474,7 +474,7 @@ private fun TrackSelectionDialog(
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(Color.Black.copy(alpha = 0.65f)),
+            .background(MaterialTheme.colorScheme.scrim.copy(alpha = 0.65f)),
         contentAlignment = Alignment.Center,
     ) {
         TvSurface(
@@ -518,7 +518,10 @@ private fun TrackSelectionDialog(
                             }
                         }
                     }
-                    items(options) { track ->
+                    items(
+                        items = options,
+                        key = { track -> "${track.groupIndex}-${track.trackIndex}-${track.displayName}" },
+                    ) { track ->
                         val isSelected = selectedId == track.displayName
                         TvCard(
                             onClick = { onSelect(track) },

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/LibraryFilters.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/LibraryFilters.kt
@@ -54,7 +54,10 @@ fun LibraryFilterRow(
             vertical = LibraryScreenDefaults.FilterChipSpacing,
         ),
     ) {
-        items(FilterType.getAllFilters()) { filter ->
+        items(
+            items = FilterType.getAllFilters(),
+            key = { filter -> filter.name },
+        ) { filter ->
             FilterChip(
                 onClick = { onFilterSelected(filter) },
                 label = { Text(filter.displayName) },


### PR DESCRIPTION
## Summary
- fix the android-ci workflow indentation so build, check, coverage, and upload steps run inside the job
- add stable keys to remaining lazy lists and track selection dialogs to reduce state reuse issues
- align playback recommendation, carousel, and TV overlays with MaterialTheme colors

## Testing
- ./gradlew testDebugUnitTest *(fails: Android SDK/local.properties not configured in CI sandbox)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952eb03e2dc832797089343c1388acc)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated UI colors throughout the app to sync with your theme settings, ensuring consistent appearance across light and dark modes.
  * Improved list rendering performance for smoother interactions when browsing content and playback queues.
  * Refined color theming in playback controls and recommendation notifications to automatically adapt to your selected theme.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->