### PR TITLE
chore: update setup script for JDK 21

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,10 +1,23 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+JDK_MAJOR=21
+OS_NAME=$(uname -s | tr '[:upper:]' '[:lower:]')
+case "$OS_NAME" in
+  linux*) HOST_OS="linux" ;;
+  msys*|mingw*|cygwin*) HOST_OS="windows" ;;
+  *)
+    HOST_OS="linux"
+    echo "⚠️  Unrecognized platform ($OS_NAME); defaulting to Linux tooling." >&2
+    ;;
+esac
+
 # Small helper to surface missing tools with a CachyOS/Arch-friendly hint.
-INSTALL_HINT="sudo apt-get install openjdk-17-jdk wget unzip zip git"
+INSTALL_HINT="sudo apt-get install openjdk-${JDK_MAJOR}-jdk wget unzip zip git"
 if command -v pacman >/dev/null 2>&1; then
-  INSTALL_HINT="sudo pacman -S --needed jdk17-openjdk wget unzip zip git base-devel"
+  INSTALL_HINT="sudo pacman -S --needed jdk${JDK_MAJOR}-openjdk wget unzip zip git base-devel"
+elif [ "$HOST_OS" = "windows" ]; then
+  INSTALL_HINT="Install Java ${JDK_MAJOR} and tooling via winget or choco (e.g., winget install --id Microsoft.OpenJDK.${JDK_MAJOR} -e; winget install Git.Git 7zip.7zip). Ensure curl or wget and unzip are available."
 fi
 
 require_cmd() {
@@ -15,21 +28,40 @@ require_cmd() {
   fi
 }
 
-require_cmd wget
+download() {
+  local url="$1" dest="$2"
+  if command -v wget >/dev/null 2>&1; then
+    wget -q "$url" -O "$dest"
+  elif command -v curl >/dev/null 2>&1; then
+    curl -sSL "$url" -o "$dest"
+  else
+    echo "❌ Missing dependency: wget or curl. Install with: $INSTALL_HINT" >&2
+    exit 1
+  fi
+}
+
 require_cmd unzip
 require_cmd zip
 require_cmd java
+require_cmd git
 
-# Warn if Java is not 17
+# Warn if Java is not the expected version
 JAVA_VERSION_OUTPUT=$(java -version 2>&1 | head -n 1 || true)
-if ! grep -qE '"17\.' <<<"$JAVA_VERSION_OUTPUT"; then
-  echo "⚠️  Java 17 recommended. Detected: $JAVA_VERSION_OUTPUT" >&2
+if ! grep -qE '"'"${JDK_MAJOR}"'\.' <<<"$JAVA_VERSION_OUTPUT"; then
+  echo "⚠️  Java ${JDK_MAJOR} recommended. Detected: $JAVA_VERSION_OUTPUT" >&2
 fi
 
 # ----- Android SDK + Build Tools -----
 : "${TARGET_API:=35}"      # change to 36 if you want Android 16 preview
 : "${BUILD_TOOLS:=35.0.0}" # latest stable
-DEFAULT_SDK_ROOT="${SDK_ROOT:-$HOME/android-sdk}"
+if [ "$HOST_OS" = "windows" ]; then
+  DEFAULT_SDK_ROOT="${SDK_ROOT:-${LOCALAPPDATA:-$HOME/AppData/Local}/Android/Sdk}"
+  ANDROID_SDK_HOME="${ANDROID_SDK_HOME:-${LOCALAPPDATA:-$HOME/AppData/Local}/Android/.android}"
+else
+  DEFAULT_SDK_ROOT="${SDK_ROOT:-$HOME/android-sdk}"
+  ANDROID_SDK_HOME="${ANDROID_SDK_HOME:-$DEFAULT_SDK_ROOT/.android}"
+fi
+
 SDK_ROOT="$DEFAULT_SDK_ROOT"
 # If the default SDK_ROOT isn't writable (e.g., sandboxed $HOME), fall back to a local directory.
 if ! mkdir -p "$SDK_ROOT" 2>/dev/null || ! touch "$SDK_ROOT/.rwtest" 2>/dev/null; then
@@ -48,12 +80,21 @@ export ANDROID_SDK_HOME
 
 TOOLS_ROOT="$SDK_ROOT/cmdline-tools"
 TOOLS_LATEST="$TOOLS_ROOT/latest"
+CMDLINE_OS_ID="linux"
+if [ "$HOST_OS" = "windows" ]; then
+  CMDLINE_OS_ID="win"
+fi
+CMDLINE_TOOLS_URL="https://dl.google.com/android/repository/commandlinetools-${CMDLINE_OS_ID}-11076708_latest.zip"
+SDK_MANAGER="$TOOLS_LATEST/bin/sdkmanager"
+if [ ! -x "$SDK_MANAGER" ] && [ -x "${SDK_MANAGER}.bat" ]; then
+  SDK_MANAGER="${SDK_MANAGER}.bat"
+fi
 
-if [ ! -x "$TOOLS_LATEST/bin/sdkmanager" ]; then
+if [ ! -x "$SDK_MANAGER" ]; then
   echo "Installing Android cmdline-tools..."
   mkdir -p "$TOOLS_ROOT"
   rm -f /tmp/cmdtools.zip
-  wget -q https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip -O /tmp/cmdtools.zip
+  download "$CMDLINE_TOOLS_URL" /tmp/cmdtools.zip
   unzip -q /tmp/cmdtools.zip -d "$TOOLS_ROOT"
   rm /tmp/cmdtools.zip
   mv "$TOOLS_ROOT/cmdline-tools" "$TOOLS_LATEST"
@@ -69,12 +110,12 @@ fi
 # Accept licenses and install required SDK components; handle sdkmanager closing stdin early.
 echo "Accepting licenses..."
 set +o pipefail
-yes 2>/dev/null | sdkmanager --sdk_root="$SDK_ROOT" --licenses >/dev/null || true
+yes 2>/dev/null | "$SDK_MANAGER" --sdk_root="$SDK_ROOT" --licenses >/dev/null || true
 set -o pipefail
 
 echo "Installing platform-tools, platform ${TARGET_API}, build-tools ${BUILD_TOOLS}..."
 set +o pipefail
-yes 2>/dev/null | sdkmanager --sdk_root="$SDK_ROOT" \
+yes 2>/dev/null | "$SDK_MANAGER" --sdk_root="$SDK_ROOT" \
   "platform-tools" \
   "platforms;android-${TARGET_API}" \
   "build-tools;${BUILD_TOOLS}" || true


### PR DESCRIPTION
## Summary
- update setup script to target JDK 21 and adjust dependency hints
- add OS detection to set SDK paths for Linux and Windows environments
- add flexible downloading and sdkmanager resolution for platform-specific command line tools

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69541467746c8327854728d4dfac9936)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced cross-platform setup initialization for Windows and Linux environments with dynamic Java version detection
  * Improved Android SDK path configuration based on operating system
  * Added fallback mechanism for SDK installation when default paths are unavailable
  * Better command-line tool compatibility and PATH management

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->