### PR TITLE
Add macOS Homebrew support to update script

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+JDK_MAJOR=21
+OS_NAME=$(uname -s | tr '[:upper:]' '[:lower:]')
+
+case "$OS_NAME" in
+  linux*) HOST_OS="linux" ;;
+  darwin*) HOST_OS="macos" ;;
+  msys*|mingw*|cygwin*) HOST_OS="windows" ;;
+  *)
+    HOST_OS="linux"
+    echo "⚠️  Unrecognized platform ($OS_NAME); defaulting to Linux tooling." >&2
+    ;;
+esac
+
+install_linux() {
+  if command -v apt-get >/dev/null 2>&1; then
+    sudo apt-get update
+    sudo apt-get install -y "openjdk-${JDK_MAJOR}-jdk" wget unzip zip git
+  elif command -v pacman >/dev/null 2>&1; then
+    sudo pacman -Syu --needed "jdk${JDK_MAJOR}-openjdk" wget unzip zip git base-devel
+  else
+    echo "❌ Unsupported Linux package manager. Install JDK ${JDK_MAJOR}, git, wget, unzip, and zip manually." >&2
+    exit 1
+  fi
+}
+
+install_macos() {
+  if ! command -v brew >/dev/null 2>&1; then
+    echo "❌ Homebrew is required on macOS. Install it from https://brew.sh and re-run this script." >&2
+    exit 1
+  fi
+
+  brew update
+  brew install "openjdk@${JDK_MAJOR}" wget unzip zip git
+  brew install --cask android-commandlinetools
+
+  JAVA_BIN_ROOT="$(brew --prefix)/opt/openjdk@${JDK_MAJOR}/bin"
+  ANDROID_CMDLINE_ROOT="$(brew --prefix)/share/android-commandlinetools"
+
+  echo ""
+  echo "➡️  Add Homebrew OpenJDK to your PATH if it is not picked up automatically:"
+  echo "    export PATH=\"${JAVA_BIN_ROOT}:\$PATH\""
+  if [ -d "$ANDROID_CMDLINE_ROOT" ]; then
+    echo "➡️  Android command-line tools installed via Homebrew. Add them to your PATH:"
+    echo "    export PATH=\"${ANDROID_CMDLINE_ROOT}/bin:\$PATH\""
+  fi
+}
+
+install_windows() {
+  echo "ℹ️  On Windows, install Java ${JDK_MAJOR}, git, wget/curl, unzip, and zip via winget or chocolatey." >&2
+}
+
+echo "Detected host: $HOST_OS"
+case "$HOST_OS" in
+  linux) install_linux ;;
+  macos) install_macos ;;
+  windows) install_windows ;;
+esac
+
+if [ -x "./setup.sh" ]; then
+  echo ""
+  echo "✅ System prerequisites installed. Run ./setup.sh to download or update the Android SDK."
+fi


### PR DESCRIPTION
## Summary
- add host detection to update.sh and include macOS handling
- install prerequisites via Homebrew on macOS including Android command-line tools
- surface PATH guidance and point to setup.sh for SDK downloads

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955728718748327bca0031183bac9f7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an update script that automatically detects your operating system and installs required prerequisites.
  * Provides guidance for environment configuration and Android tools setup based on your system type.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->