### PR TITLE
Restore auto login when saved credentials exist

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/ui/viewmodel/ServerConnectionViewModel.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/viewmodel/ServerConnectionViewModel.kt
@@ -62,7 +62,7 @@ class ServerConnectionViewModel @Inject constructor(
             val preferences = context.dataStore.data.first()
             val savedServerUrl = preferences[PreferencesKeys.SERVER_URL] ?: ""
             val savedUsername = preferences[PreferencesKeys.USERNAME] ?: ""
-            val rememberLogin = preferences[PreferencesKeys.REMEMBER_LOGIN] ?: false
+            var rememberLogin = preferences[PreferencesKeys.REMEMBER_LOGIN] ?: false
             val isBiometricAuthEnabled = preferences[PreferencesKeys.BIOMETRIC_AUTH_ENABLED] ?: false
 
             // ✅ FIX: Handle suspend function calls properly
@@ -70,6 +70,14 @@ class ServerConnectionViewModel @Inject constructor(
                 secureCredentialManager.getPassword(savedServerUrl, savedUsername) != null
             } else {
                 false
+            }
+
+            // If credentials exist but the toggle was never persisted, opt the user back in
+            if (hasSavedPassword && !rememberLogin) {
+                context.dataStore.edit { prefs ->
+                    prefs[PreferencesKeys.REMEMBER_LOGIN] = true
+                }
+                rememberLogin = true
             }
 
             _connectionState.value = _connectionState.value.copy(


### PR DESCRIPTION
## Summary
- ensure saved credentials re-enable the remember-login preference so returning users are auto-signed in
- keep biometric opt-out intact while restoring automatic login for remembered sessions

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69572761ebd08327ac7c66202409f718)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed login credential handling to automatically enable "Remember Login" for existing saved credentials, even if the preference wasn't previously persisted. This improves the auto-login experience on app initialization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->