### PR TITLE
Add Fedora 43 setup instructions

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -14,7 +14,9 @@ esac
 
 # Small helper to surface missing tools with a CachyOS/Arch-friendly hint.
 INSTALL_HINT="sudo apt-get install openjdk-${JDK_MAJOR}-jdk wget unzip zip git"
-if command -v pacman >/dev/null 2>&1; then
+if command -v dnf >/dev/null 2>&1; then
+  INSTALL_HINT="sudo dnf install -y java-${JDK_MAJOR}-openjdk java-${JDK_MAJOR}-openjdk-devel wget unzip zip git"
+elif command -v pacman >/dev/null 2>&1; then
   INSTALL_HINT="sudo pacman -S --needed jdk${JDK_MAJOR}-openjdk wget unzip zip git base-devel"
 elif [ "$HOST_OS" = "windows" ]; then
   INSTALL_HINT="Install Java ${JDK_MAJOR} and tooling via winget or choco (e.g., winget install --id Microsoft.OpenJDK.${JDK_MAJOR} -e; winget install Git.Git 7zip.7zip). Ensure curl or wget and unzip are available."

--- a/update.sh
+++ b/update.sh
@@ -18,6 +18,8 @@ install_linux() {
   if command -v apt-get >/dev/null 2>&1; then
     sudo apt-get update
     sudo apt-get install -y "openjdk-${JDK_MAJOR}-jdk" wget unzip zip git
+  elif command -v dnf >/dev/null 2>&1; then
+    sudo dnf install -y "java-${JDK_MAJOR}-openjdk" "java-${JDK_MAJOR}-openjdk-devel" wget unzip zip git
   elif command -v pacman >/dev/null 2>&1; then
     sudo pacman -Syu --needed "jdk${JDK_MAJOR}-openjdk" wget unzip zip git base-devel
   else


### PR DESCRIPTION
## Summary
- add Fedora 43 dnf installation hint to setup.sh for required build dependencies
- handle dnf-based Fedora setup in update.sh alongside existing package managers

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69573e70ebf4832799ac6d4ac8a32b43)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added support for Fedora-based Linux systems (dnf package manager) in setup and installation processes.
  * Enhanced package manager detection to provide accurate installation instructions across different Linux distributions.
  * Updated dependency installation guidance for improved cross-platform compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->