### PR TITLE
fix: guard secure credential logging

### DIFF
--- a/app/src/test/java/com/rpeters/jellyfin/data/SecureCredentialManagerTest.kt
+++ b/app/src/test/java/com/rpeters/jellyfin/data/SecureCredentialManagerTest.kt
@@ -1,9 +1,14 @@
 package com.rpeters.jellyfin.data
 
 import android.content.Context
+import com.rpeters.jellyfin.utils.SecureLogger
 import com.rpeters.jellyfin.utils.normalizeServerUrl
 import com.rpeters.jellyfin.utils.normalizeServerUrlLegacy
+import io.mockk.justRun
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -50,5 +55,22 @@ class SecureCredentialManagerTest {
     fun `normalizeServerUrlLegacy retains port`() {
         val normalized = normalizeServerUrlLegacy(" HTTPS://Example.com:8096/ ")
         assertEquals("https://example.com:8096", normalized)
+    }
+
+    @Test
+    fun `debug logs are suppressed when not in debug mode`() {
+        mockkObject(SecureLogger)
+        try {
+            val originalFlag = manager.debugLoggingEnabled
+            justRun { SecureLogger.d(any(), any(), any()) }
+            manager.debugLoggingEnabled = false
+
+            manager.logDebug { "should not log" }
+
+            verify(exactly = 0) { SecureLogger.d(any(), any(), any()) }
+        } finally {
+            manager.debugLoggingEnabled = originalFlag
+            unmockkObject(SecureLogger)
+        }
     }
 }


### PR DESCRIPTION
### Motivation

- Prevent sensitive key names, counts, and other credential details from being emitted in release logs by routing debug output through the secure logger and a debug guard.
- Centralize debug-only messages for `SecureCredentialManager` so only debug builds can emit detailed internal state.
- Provide test coverage to assert that logging is suppressed when debug logging is disabled.

### Description

- Reworked `SecureCredentialManager` to import and use `SecureLogger` and `BuildConfig` instead of ad-hoc `Log` calls and plaintext logging of keys.
- Added an internal `debugLoggingEnabled` flag and a `logDebug` helper (`logDebug { ... }`) to gate debug messages and route them to `SecureLogger` when enabled.
- Replaced many `android.util.Log.*` calls in `SecureCredentialManager` with either `logDebug { ... }` (for debug-only messages) or `SecureLogger.*` (for warnings/errors that should still be sanitized).
- Added a unit test `debug logs are suppressed when not in debug mode` in `app/src/test/java/com/rpeters/jellyfin/data/SecureCredentialManagerTest.kt` that mocks `SecureLogger` and verifies no `SecureLogger.d` call is made when `debugLoggingEnabled` is false.

### Testing

- Added unit test `debug logs are suppressed when not in debug mode` that mocks `SecureLogger` and asserts no debug call when `manager.debugLoggingEnabled` is false.
- Attempted to run unit tests via `./gradlew testDebugUnitTest`, but the build failed in this environment because the Android SDK location is not configured (missing `ANDROID_HOME` or `local.properties`).
- No instrumentation or lint jobs were run as part of this change in the current environment due to missing SDK configuration.
- Files changed: `app/src/main/java/com/rpeters/jellyfin/data/SecureCredentialManager.kt` and `app/src/test/java/com/rpeters/jellyfin/data/SecureCredentialManagerTest.kt`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d78885cec8327b66862cd92f23aaf)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens credential logging hygiene by centralizing and gating debug output.
> 
> - Introduces `debugLoggingEnabled` (defaults to `BuildConfig.DEBUG`) and `logDebug { ... }` in `SecureCredentialManager` to emit debug logs only in debug builds
> - Replaces many `android.util.Log.*` calls with `logDebug { ... }` for debug-only messages and `SecureLogger.*` for warnings/errors
> - Keeps functional behavior intact (encryption, keystore, DataStore) while sanitizing log emission
> - Adds unit test `SecureCredentialManagerTest` verifying that `SecureLogger.d` is not called when `debugLoggingEnabled` is false
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1e452b1d311c2f5f32fa6f8106a0481be509a55. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for debug logging behavior.

* **Chores**
  * Improved internal logging infrastructure to provide better control and visibility during development and debugging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->