### PR TITLE
fix: restrict cleartext traffic to debug builds

### DIFF
--- a/app/src/debug/res/xml/network_security_config.xml
+++ b/app/src/debug/res/xml/network_security_config.xml
@@ -12,9 +12,10 @@
     <domain-config cleartextTrafficPermitted="true">
         <domain includeSubdomains="false">localhost</domain>
         <domain includeSubdomains="false">127.0.0.1</domain>
-        <domain includeSubdomains="false">10.0.0.0</domain>
-        <domain includeSubdomains="false">192.168.0.0</domain>
-        <domain includeSubdomains="false">172.16.0.0</domain>
+        <!-- 10.0.2.2 is the special alias for the host loopback from the Android emulator -->
+        <domain includeSubdomains="false">10.0.2.2</domain>
+        <!-- Add specific local IPs when testing on a physical device -->
+        <!-- e.g., <domain includeSubdomains="false">192.168.1.100</domain> -->
         <!-- Add your local development domain here -->
         <!-- <domain includeSubdomains="true">your-local-jellyfin.local</domain> -->
     </domain-config>

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -14,7 +14,7 @@
         </trust-anchors>
     </base-config>
     
-    <!-- Allow custom trust anchors in debug builds while keeping release HTTPS-only -->
+    <!-- Allow system and user certificate trust anchors in debug builds while keeping release HTTPS-only -->
     <debug-overrides>
         <trust-anchors>
             <!-- Trust system certificate store -->


### PR DESCRIPTION
### Motivation
- Remove cleartext allowances from the release network security configuration so production builds default to HTTPS-only.
- Provide a development-friendly override that permits cleartext for common local endpoints used during testing and local Jellyfin development.
- Record a migration note in `app/src/main/res/xml/network_security_config.xml` explaining where cleartext allowances now live.

### Description
- Updated `app/src/main/res/xml/network_security_config.xml` to enforce HTTPS by default and added a migration comment documenting the change.
- Added a debug-only overlay file `app/src/debug/res/xml/network_security_config.xml` that permits cleartext traffic to common local endpoints such as `localhost` and `127.0.0.1` for debug builds.
- Preserved debug trust-anchor behavior to allow system/user test certificates in debug builds without weakening release security.

### Testing
- No automated tests were executed as part of this change.
- Recommended automated checks to run before review: `./gradlew testDebugUnitTest` and `./gradlew lintDebug`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d78889410832782c37fa7c67a9338)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Separates network security settings so release builds are HTTPS-only while debug builds support local HTTP testing.
> 
> - Adds `app/src/debug/res/xml/network_security_config.xml` permitting cleartext to `localhost`, `127.0.0.1`, and `10.0.2.2` for development
> - Updates `app/src/main/res/xml/network_security_config.xml` to enforce HTTPS-only, remove prior cleartext domain allowances, and document the migration; retains `debug-overrides` trust anchors
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 653fa29ac29c2e30b9d8beb64b19dcf9d5491c8d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Separated network security configurations for development and production. Production now enforces HTTPS-only, while debug builds allow local HTTP for development/testing; documentation/comments updated to reflect the change.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->