### PR TITLE
feat: fade detail hero images into background

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/MovieDetailScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/MovieDetailScreen.kt
@@ -157,7 +157,7 @@ fun MovieDetailScreen(
                                 modifier = Modifier.fillMaxSize(),
                             )
 
-                            // Subtle gradient at bottom for logo visibility
+                            // Fade image into the screen background near the bottom edge
                             Box(
                                 modifier = Modifier
                                     .fillMaxSize()
@@ -166,9 +166,8 @@ fun MovieDetailScreen(
                                             colors = listOf(
                                                 androidx.compose.ui.graphics.Color.Transparent,
                                                 androidx.compose.ui.graphics.Color.Transparent,
-                                                androidx.compose.ui.graphics.Color.Transparent,
-                                                androidx.compose.ui.graphics.Color.Black.copy(alpha = 0.1f),
-                                                androidx.compose.ui.graphics.Color.Black.copy(alpha = 0.3f),
+                                                MaterialTheme.colorScheme.background.copy(alpha = 0.6f),
+                                                MaterialTheme.colorScheme.background,
                                             ),
                                             startY = 0f,
                                             endY = Float.POSITIVE_INFINITY,

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/TVSeasonScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/TVSeasonScreen.kt
@@ -388,7 +388,7 @@ private fun SeriesDetailsHeader(
                 modifier = Modifier.fillMaxSize(),
             )
 
-            // Subtle gradient at bottom for logo visibility
+            // Fade image into the screen background near the bottom edge
             Box(
                 modifier = Modifier
                     .fillMaxSize()
@@ -397,9 +397,8 @@ private fun SeriesDetailsHeader(
                             colors = listOf(
                                 Color.Transparent,
                                 Color.Transparent,
-                                Color.Transparent,
-                                Color.Black.copy(alpha = 0.1f),
-                                Color.Black.copy(alpha = 0.3f),
+                                MaterialTheme.colorScheme.background.copy(alpha = 0.6f),
+                                MaterialTheme.colorScheme.background,
                             ),
                         ),
                     ),


### PR DESCRIPTION
### Motivation
- Improve visual continuity on detail screens by making the hero/backdrop image fade into the screen background so the image reaches the top and smoothly transitions at the bottom.

### Description
- Replace the previous black-tinted bottom gradient with a background-based vertical gradient using `MaterialTheme.colorScheme.background` in `app/src/main/java/com/rpeters/jellyfin/ui/screens/MovieDetailScreen.kt` and `app/src/main/java/com/rpeters/jellyfin/ui/screens/TVSeasonScreen.kt` so hero/backdrop images fade into the screen background.

### Testing
- No automated tests were executed for this change (run `./gradlew testDebugUnitTest` and `./gradlew lintDebug` locally or in CI to validate).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967e019a94c832788c6e9e48f83f117)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated gradient overlays on movie detail and TV season screens to use dynamic theme colors instead of fixed tones, providing a more cohesive visual appearance that adapts to your app theme settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->