### PR TITLE
fix: improve audio/subtitle track labels and make selection dialogs scrollable

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/ui/player/VideoPlayerScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/player/VideoPlayerScreen.kt
@@ -10,8 +10,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -24,7 +22,9 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.VolumeOff

--- a/app/src/main/java/com/rpeters/jellyfin/ui/player/VideoPlayerViewModel.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/player/VideoPlayerViewModel.kt
@@ -760,7 +760,7 @@ class VideoPlayerViewModel @Inject constructor(
 
         return buildString {
             append(primary)
-            if (descriptor != null) append(" (${descriptor})")
+            if (descriptor != null) append(" ($descriptor)")
             if (trackType == androidx.media3.common.C.TRACK_TYPE_AUDIO) {
                 if (format.channelCount != androidx.media3.common.Format.NO_VALUE && format.channelCount > 0) {
                     append(" • ${format.channelCount}ch")


### PR DESCRIPTION
### Motivation
- Selection lists for audio tracks and subtitles displayed terse language codes (e.g. "en", "it") and could be cut off when there are many entries, so the UX needed clearer, localized labels and scrollable dialogs.
- The goal is to present track options more professionally (e.g. "English", "Italian") and ensure all options are reachable on small screens.

### Description
- Replaced inline `display` string construction with a reusable `buildTrackDisplayName` helper in `VideoPlayerViewModel.kt` and added `toDisplayLanguage()` plus a `Locale` import to format language codes into localized names when available.
- The new label logic prefers descriptive `label` values, falls back to localized language names, uppercased short labels, or a `Track N` fallback, and preserves audio descriptors such as channel count and sample rate in the display string.
- Made audio and subtitle selection dialogs in `VideoPlayerScreen.kt` scrollable by adding `rememberScrollState`/`verticalScroll` and bounding their height with `heightIn(max = dialogMaxHeight)` where `dialogMaxHeight` is derived from `LocalConfiguration.screenHeightDp`.
- Updated imports and UI modifiers required to support the scrollable dialog layout and constrained height.

### Testing
- No automated tests were run on this change in this environment; please run `./gradlew testDebugUnitTest` and `./gradlew lintDebug` locally or in CI to validate build and lint rules.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696810f2c2f883279ae8adfe03622137)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Audio and subtitle selection dialogs now scroll when displaying many options, preventing content overflow.
  * Track labels now display language information and audio details (channel count and sample rate) for better clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->