### PR TITLE
fix: reduce build warnings

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -61,6 +61,7 @@ android {
                 listOf(
                     "-opt-in=androidx.compose.material3.ExperimentalMaterial3Api",
                     "-opt-in=androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi",
+                    "-Xannotation-default-target=param-property",
                 ),
             )
         }

--- a/app/src/main/java/com/rpeters/jellyfin/data/BiometricAuthManager.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/data/BiometricAuthManager.kt
@@ -151,11 +151,7 @@ class BiometricAuthManager(private val context: Context) {
                 BiometricManager.Authenticators.BIOMETRIC_WEAK or deviceCredentialAuth
             }
         }
-        val status = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R && allowsDeviceCredentialFallback) {
-            biometricManager.canAuthenticate()
-        } else {
-            biometricManager.canAuthenticate(authenticators)
-        }
+        val status = biometricManager.canAuthenticate(authenticators)
 
         return BiometricCapability(
             authenticators = authenticators,

--- a/app/src/main/java/com/rpeters/jellyfin/data/SecureCredentialManager.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/data/SecureCredentialManager.kt
@@ -219,7 +219,15 @@ class SecureCredentialManager @Inject constructor(
             .setUserAuthenticationRequired(requireUserAuthentication)
             .apply {
                 if (requireUserAuthentication) {
-                    setUserAuthenticationValidityDurationSeconds(USER_AUTH_VALIDITY_WINDOW_SECONDS)
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                        setUserAuthenticationParameters(
+                            USER_AUTH_VALIDITY_WINDOW_SECONDS,
+                            KeyProperties.AUTH_BIOMETRIC_STRONG or KeyProperties.AUTH_DEVICE_CREDENTIAL,
+                        )
+                    } else {
+                        @Suppress("DEPRECATION")
+                        setUserAuthenticationValidityDurationSeconds(USER_AUTH_VALIDITY_WINDOW_SECONDS)
+                    }
                 }
             }
             .build()
@@ -525,7 +533,7 @@ class SecureCredentialManager @Inject constructor(
         val credentials = mutableListOf<StoredCredential>()
 
         preferences.asMap().forEach { (key, value) ->
-            if (key is Preferences.Key<*> && key.name.startsWith("pwd_") && !key.name.endsWith("_timestamp")) {
+            if (key.name.startsWith("pwd_") && !key.name.endsWith("_timestamp")) {
                 val encryptedPassword = value as? String ?: return@forEach
                 val decryptedPassword = decrypt(encryptedPassword)
                 if (decryptedPassword == null) {

--- a/app/src/main/java/com/rpeters/jellyfin/ui/components/MiniPlayer.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/components/MiniPlayer.kt
@@ -40,7 +40,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.media3.common.MediaItem
 import com.rpeters.jellyfin.OptInAppExperimentalApis
 import com.rpeters.jellyfin.ui.image.JellyfinAsyncImage

--- a/app/src/main/java/com/rpeters/jellyfin/ui/navigation/AuthNavGraph.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/navigation/AuthNavGraph.kt
@@ -23,7 +23,7 @@ fun androidx.navigation.NavGraphBuilder.authNavGraph(
     navController: NavHostController,
 ) {
     composable(Screen.ServerConnection.route) {
-        val viewModel: ServerConnectionViewModel = androidx.hilt.navigation.compose.hiltViewModel()
+        val viewModel: ServerConnectionViewModel = androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel()
         val lifecycleOwner = LocalLifecycleOwner.current
         val context = LocalContext.current
         val connectionState by viewModel.connectionState.collectAsStateWithLifecycle(
@@ -73,7 +73,7 @@ fun androidx.navigation.NavGraphBuilder.authNavGraph(
     }
 
     composable(Screen.QuickConnect.route) {
-        val viewModel: ServerConnectionViewModel = androidx.hilt.navigation.compose.hiltViewModel()
+        val viewModel: ServerConnectionViewModel = androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel()
         val lifecycleOwner = LocalLifecycleOwner.current
         val connectionState by viewModel.connectionState.collectAsStateWithLifecycle(
             lifecycle = lifecycleOwner.lifecycle,

--- a/app/src/main/java/com/rpeters/jellyfin/ui/navigation/DetailNavGraph.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/navigation/DetailNavGraph.kt
@@ -56,7 +56,7 @@ fun androidx.navigation.NavGraphBuilder.detailNavGraph(
     ) { backStackEntry ->
         val albumId =
             backStackEntry.arguments?.getString(Screen.ALBUM_ID_ARG) ?: return@composable
-        val mainViewModel = androidx.hilt.navigation.compose.hiltViewModel<MainAppViewModel>()
+        val mainViewModel = androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel<MainAppViewModel>()
         AlbumDetailScreen(
             albumId = albumId,
             onBackClick = { navController.popBackStack() },
@@ -73,7 +73,7 @@ fun androidx.navigation.NavGraphBuilder.detailNavGraph(
         val artistId =
             backStackEntry.arguments?.getString(Screen.ARTIST_ID_ARG) ?: return@composable
         val artistName: String? = null
-        val mainViewModel = androidx.hilt.navigation.compose.hiltViewModel<MainAppViewModel>()
+        val mainViewModel = androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel<MainAppViewModel>()
         ArtistDetailScreen(
             artistId = artistId,
             artistName = artistName,
@@ -94,8 +94,8 @@ fun androidx.navigation.NavGraphBuilder.detailNavGraph(
             SecureLogger.e("NavGraph", "HomeVideoDetail navigation cancelled: videoId is null or blank")
             return@composable
         }
-        val mainViewModel = androidx.hilt.navigation.compose.hiltViewModel<MainAppViewModel>()
-        val detailViewModel = androidx.hilt.navigation.compose.hiltViewModel<ItemDetailViewModel>()
+        val mainViewModel = androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel<MainAppViewModel>()
+        val detailViewModel = androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel<ItemDetailViewModel>()
         LaunchedEffect(videoId) {
             try {
                 detailViewModel.load(videoId)
@@ -150,8 +150,8 @@ fun androidx.navigation.NavGraphBuilder.detailNavGraph(
     ) { backStackEntry ->
         val itemId =
             backStackEntry.arguments?.getString(Screen.ITEM_ID_ARG) ?: return@composable
-        val mainViewModel = androidx.hilt.navigation.compose.hiltViewModel<MainAppViewModel>()
-        val detailViewModel = androidx.hilt.navigation.compose.hiltViewModel<ItemDetailViewModel>()
+        val mainViewModel = androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel<MainAppViewModel>()
+        val detailViewModel = androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel<ItemDetailViewModel>()
         LaunchedEffect(itemId) {
             try {
                 detailViewModel.load(itemId)
@@ -215,8 +215,8 @@ fun androidx.navigation.NavGraphBuilder.detailNavGraph(
             SecureLogger.e("NavGraph", "MovieDetail navigation cancelled: movieId is null or blank")
             return@composable
         }
-        val mainViewModel = androidx.hilt.navigation.compose.hiltViewModel<MainAppViewModel>()
-        val detailViewModel = androidx.hilt.navigation.compose.hiltViewModel<MovieDetailViewModel>()
+        val mainViewModel = androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel<MainAppViewModel>()
+        val detailViewModel = androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel<MovieDetailViewModel>()
 
         val lifecycleOwner = LocalLifecycleOwner.current
         val appState by mainViewModel.appState.collectAsStateWithLifecycle(
@@ -295,8 +295,8 @@ fun androidx.navigation.NavGraphBuilder.detailNavGraph(
             return@composable
         }
 
-        val mainViewModel = androidx.hilt.navigation.compose.hiltViewModel<MainAppViewModel>()
-        val viewModel = androidx.hilt.navigation.compose.hiltViewModel<TVEpisodeDetailViewModel>()
+        val mainViewModel = androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel<MainAppViewModel>()
+        val viewModel = androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel<TVEpisodeDetailViewModel>()
         val lifecycleOwner = LocalLifecycleOwner.current
         val appState by mainViewModel.appState.collectAsStateWithLifecycle(
             lifecycle = lifecycleOwner.lifecycle,

--- a/app/src/main/java/com/rpeters/jellyfin/ui/navigation/HomeLibraryNavGraph.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/navigation/HomeLibraryNavGraph.kt
@@ -23,7 +23,7 @@ fun androidx.navigation.NavGraphBuilder.homeLibraryNavGraph(
     navController: NavHostController,
 ) {
     composable(Screen.Home.route) {
-        val viewModel: MainAppViewModel = androidx.hilt.navigation.compose.hiltViewModel()
+        val viewModel: MainAppViewModel = androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel()
         val lifecycleOwner = LocalLifecycleOwner.current
         val appState by viewModel.appState.collectAsStateWithLifecycle(
             lifecycle = lifecycleOwner.lifecycle,
@@ -118,7 +118,7 @@ fun androidx.navigation.NavGraphBuilder.homeLibraryNavGraph(
     }
 
     composable(Screen.Library.route) {
-        val viewModel = androidx.hilt.navigation.compose.hiltViewModel<MainAppViewModel>()
+        val viewModel = androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel<MainAppViewModel>()
         val lifecycleOwner = LocalLifecycleOwner.current
         val appState by viewModel.appState.collectAsStateWithLifecycle(
             lifecycle = lifecycleOwner.lifecycle,

--- a/app/src/main/java/com/rpeters/jellyfin/ui/navigation/MediaNavGraph.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/navigation/MediaNavGraph.kt
@@ -96,7 +96,7 @@ fun androidx.navigation.NavGraphBuilder.mediaNavGraph(
             SecureLogger.e("NavGraph", "TVSeasons navigation cancelled: seriesId is null or blank")
             return@composable
         }
-        val viewModel = androidx.hilt.navigation.compose.hiltViewModel<MainAppViewModel>()
+        val viewModel = androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel<MainAppViewModel>()
         LocalLifecycleOwner.current
 
         LaunchedEffect(seriesId) {
@@ -129,8 +129,8 @@ fun androidx.navigation.NavGraphBuilder.mediaNavGraph(
             SecureLogger.e("NavGraph", "TVEpisodes navigation cancelled: seasonId is null or blank")
             return@composable
         }
-        val viewModel = androidx.hilt.navigation.compose.hiltViewModel<SeasonEpisodesViewModel>()
-        val mainViewModel = androidx.hilt.navigation.compose.hiltViewModel<MainAppViewModel>()
+        val viewModel = androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel<SeasonEpisodesViewModel>()
+        val mainViewModel = androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel<MainAppViewModel>()
         LocalLifecycleOwner.current
 
         LaunchedEffect(seasonId) {
@@ -279,7 +279,7 @@ fun androidx.navigation.NavGraphBuilder.mediaNavGraph(
             SecureLogger.e("NavGraph", "Stuff navigation cancelled: libraryId is null or blank")
             return@composable
         }
-        val viewModel = androidx.hilt.navigation.compose.hiltViewModel<MainAppViewModel>()
+        val viewModel = androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel<MainAppViewModel>()
         val lifecycleOwner = LocalLifecycleOwner.current
         val appState by viewModel.appState.collectAsStateWithLifecycle(
             lifecycle = lifecycleOwner.lifecycle,

--- a/app/src/main/java/com/rpeters/jellyfin/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/navigation/NavGraph.kt
@@ -4,7 +4,7 @@ package com.rpeters.jellyfin.ui.navigation
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.rememberNavController

--- a/app/src/main/java/com/rpeters/jellyfin/ui/navigation/ProfileNavGraph.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/navigation/ProfileNavGraph.kt
@@ -24,7 +24,7 @@ fun androidx.navigation.NavGraphBuilder.profileNavGraph(
     onLogout: () -> Unit,
 ) {
     composable(Screen.Search.route) {
-        val viewModel = androidx.hilt.navigation.compose.hiltViewModel<MainAppViewModel>()
+        val viewModel = androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel<MainAppViewModel>()
         val lifecycleOwner = LocalLifecycleOwner.current
         val appState by viewModel.appState.collectAsStateWithLifecycle(
             lifecycle = lifecycleOwner.lifecycle,
@@ -42,7 +42,7 @@ fun androidx.navigation.NavGraphBuilder.profileNavGraph(
     }
 
     composable(Screen.Favorites.route) {
-        val viewModel = androidx.hilt.navigation.compose.hiltViewModel<MainAppViewModel>()
+        val viewModel = androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel<MainAppViewModel>()
         val lifecycleOwner = LocalLifecycleOwner.current
         val appState by viewModel.appState.collectAsStateWithLifecycle(
             lifecycle = lifecycleOwner.lifecycle,
@@ -65,7 +65,7 @@ fun androidx.navigation.NavGraphBuilder.profileNavGraph(
     }
 
     composable(Screen.Profile.route) {
-        val viewModel = androidx.hilt.navigation.compose.hiltViewModel<MainAppViewModel>()
+        val viewModel = androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel<MainAppViewModel>()
         val lifecycleOwner = LocalLifecycleOwner.current
         val currentServer by viewModel.currentServer.collectAsStateWithLifecycle(
             lifecycle = lifecycleOwner.lifecycle,

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/AudioQueueScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/AudioQueueScreen.kt
@@ -46,7 +46,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.media3.common.MediaItem
 import com.rpeters.jellyfin.OptInAppExperimentalApis
 import com.rpeters.jellyfin.ui.image.JellyfinAsyncImage

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/NowPlayingScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/NowPlayingScreen.kt
@@ -53,7 +53,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.media3.common.Player
 import com.rpeters.jellyfin.OptInAppExperimentalApis
 import com.rpeters.jellyfin.ui.image.JellyfinAsyncImage

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/SettingsScreen.kt
@@ -33,7 +33,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.rpeters.jellyfin.OptInAppExperimentalApis
 import com.rpeters.jellyfin.R

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/settings/PinningSettingsScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/settings/PinningSettingsScreen.kt
@@ -29,7 +29,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.rpeters.jellyfin.R
 import com.rpeters.jellyfin.ui.viewmodel.PinnedHostState


### PR DESCRIPTION
### Motivation
- Reduce a set of Kotlin/Android build warnings related to annotation targets, deprecated biometric/keystore APIs, and deprecated Compose Hilt ViewModel imports to keep the codebase up-to-date and reduce noise during CI builds.

### Description
- Add the compiler argument `-Xannotation-default-target=param-property` to `app/build.gradle.kts` to opt-in to the new annotation default target behavior and silence related Kotlin warnings.
- Simplify biometric capability checks in `BiometricAuthManager` by using `biometricManager.canAuthenticate(authenticators)` and removing the deprecated no-arg fallback branch.
- Update key generation in `SecureCredentialManager` to use `setUserAuthenticationParameters(...)` on API >= `R` and fall back to the deprecated `setUserAuthenticationValidityDurationSeconds(...)` (with a `@Suppress("DEPRECATION")`) on older APIs, and simplify the credential export iteration by removing an unnecessary `Preferences.Key` type check.
- Migrate Compose Hilt ViewModel usages from `androidx.hilt.navigation.compose.hiltViewModel` to `androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel` across multiple navigation and UI screen files to address deprecation and align with the current package.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969cc476ad88327b19192eecb059607)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactoring**
  - Updated dependency injection framework imports across multiple screens and navigation components for improved lifecycle management
  - Simplified biometric authentication capability detection logic

* **Bug Fixes**
  - Added version-aware authentication parameter handling to ensure compatibility across Android versions
  - Updated credential export mechanism for better data migration support

* **Chores**
  - Updated Kotlin compiler configuration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->