### PR TITLE
fix: use episode imagery and backdrops on TV show screens

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/ui/components/tv/TvContentCarousel.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/components/tv/TvContentCarousel.kt
@@ -160,7 +160,7 @@ fun TvContentCard(
         ) {
             Box(modifier = Modifier.fillMaxSize()) {
                 val imageUrl = if (item.type == org.jellyfin.sdk.model.api.BaseItemKind.EPISODE) {
-                    getSeriesImageUrl(item)
+                    getImageUrl(item) ?: getSeriesImageUrl(item)
                 } else {
                     getImageUrl(item)
                 }

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/TVShowsContent.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/TVShowsContent.kt
@@ -253,15 +253,16 @@ internal fun TVShowsContent(
                                 },
                                 overline = tvShow.productionYear?.toString(),
                                 leadingContent = {
+                                    val listImageUrl = getBackdropUrl(tvShow) ?: getImageUrl(tvShow)
                                     JellyfinAsyncImage(
-                                        model = getImageUrl(tvShow),
+                                        model = listImageUrl,
                                         contentDescription = tvShow.name,
                                         modifier = Modifier
-                                            .width(72.dp)
-                                            .height(96.dp)
+                                            .width(128.dp)
+                                            .height(72.dp)
                                             .clip(RoundedCornerShape(12.dp)),
                                         contentScale = ContentScale.Crop,
-                                        requestSize = rememberCoilSize(72.dp, 96.dp),
+                                        requestSize = rememberCoilSize(128.dp, 72.dp),
                                     )
                                 },
                                 trailingContent = {

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/tv/TvHomeScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/tv/TvHomeScreen.kt
@@ -38,7 +38,7 @@ import androidx.tv.material3.MaterialTheme as TvMaterialTheme
 import androidx.tv.material3.Text as TvText
 
 private const val RECENT_MOVIES_ID = "recent_movies"
-private const val RECENT_TV_SHOWS_ID = "recent_tv_shows"
+private const val RECENT_TV_SHOW_EPISODES_ID = "recent_tv_show_episodes"
 private const val ALL_MOVIES_ID = "all_movies"
 private const val ALL_TV_SHOWS_ID = "all_tv_shows"
 
@@ -65,7 +65,7 @@ fun TvHomeScreen(
     }
 
     val recentMovies = appState.recentlyAddedByTypes[BaseItemKind.MOVIE.name]?.take(10) ?: emptyList()
-    val recentTvShows = appState.recentlyAddedByTypes[BaseItemKind.SERIES.name]?.take(10) ?: emptyList()
+    val recentTvShowEpisodes = appState.recentlyAddedByTypes[BaseItemKind.EPISODE.name]?.take(10) ?: emptyList()
     val allMovies = appState.allMovies.take(10)
     val allTvShows = appState.allTVShows.take(10)
 
@@ -77,9 +77,9 @@ fun TvHomeScreen(
             isLoading = appState.isLoading,
         ),
         TvHomeMediaSection(
-            id = RECENT_TV_SHOWS_ID,
-            title = "Recently Added TV Shows",
-            items = recentTvShows,
+            id = RECENT_TV_SHOW_EPISODES_ID,
+            title = "Recently Added TV Show Episodes",
+            items = recentTvShowEpisodes,
             isLoading = appState.isLoading,
         ),
         TvHomeMediaSection(


### PR DESCRIPTION
### Motivation
- The TV home carousel was labeling a section for TV show episodes but displayed series artwork, and TV show list rows used vertical posters that don't match the horizontal list layout.
- Align visuals so the recently added carousel shows episode artwork and list thumbnails use horizontal/backdrop images for better visual consistency.

### Description
- Changed the TV home section to surface recently added episodes by switching the data source from `BaseItemKind.SERIES` to `BaseItemKind.EPISODE` and updated the section id/title in `app/src/main/java/com/rpeters/jellyfin/ui/screens/tv/TvHomeScreen.kt`.
- Updated `TvContentCarousel` so episode items use their own image when available and fall back to the series image via `getImageUrl(item) ?: getSeriesImageUrl(item)` in `app/src/main/java/com/rpeters/jellyfin/ui/components/tv/TvContentCarousel.kt`.
- Switched the TV show list leading thumbnail to prefer the backdrop image and use a horizontal size (`128x72`) instead of the vertical poster in `app/src/main/java/com/rpeters/jellyfin/ui/screens/TVShowsContent.kt`.
- Files modified: `TvHomeScreen.kt`, `TvContentCarousel.kt`, and `TVShowsContent.kt`.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977ca444a9483279812c0014ed789a7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved episode image display with fallback logic in TV carousels.
  * Enhanced list view item images with backdrop alternatives and adjusted dimensions.
  * Updated recent content section to display recently added TV show episodes instead of shows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->