### PR TITLE
fix: improve light mode text contrast

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/ui/theme/Theme.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/theme/Theme.kt
@@ -100,8 +100,10 @@ fun JellyfinAndroidTheme(
         isDark = darkTheme,
     )
 
+    val tunedColorScheme = applyLightModeTextContrast(adjustedColorScheme, darkTheme)
+
     MaterialTheme(
-        colorScheme = adjustedColorScheme,
+        colorScheme = tunedColorScheme,
         typography = Typography,
         shapes = JellyfinShapes,
         content = content,
@@ -389,5 +391,19 @@ internal fun adjustBrightness(
         green = (color.green * factor).coerceIn(0f, 1f),
         blue = (color.blue * factor).coerceIn(0f, 1f),
         alpha = color.alpha,
+    )
+}
+
+/**
+ * Nudge light-mode secondary text colors darker to improve readability.
+ */
+private fun applyLightModeTextContrast(
+    colorScheme: ColorScheme,
+    isDark: Boolean,
+): ColorScheme {
+    if (isDark) return colorScheme
+
+    return colorScheme.copy(
+        onSurfaceVariant = adjustBrightness(colorScheme.onSurfaceVariant, 0.85f),
     )
 }


### PR DESCRIPTION
### Motivation
- Light theme secondary/variant text (notably in carousels and other secondary labels) was too light and difficult to read, so the theme needs a small tweak to increase readability in light mode.

### Description
- Modified `JellyfinAndroidTheme` to run a new `applyLightModeTextContrast` step after `applyContrastLevel` and use the resulting `tunedColorScheme` in `MaterialTheme`, and added `applyLightModeTextContrast` which darkens `onSurfaceVariant` in light mode by calling `adjustBrightness(colorScheme.onSurfaceVariant, 0.85f)`; changes are in `app/src/main/java/com/rpeters/jellyfin/ui/theme/Theme.kt`.

### Testing
- No automated tests were executed for this change; `./gradlew testDebugUnitTest` and `./gradlew lintDebug` were not run in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977cdbda69483279f464c3eb947601b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text contrast in light mode for better readability across the app interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->