### PR TITLE
fix: improve hero carousel overlay contrast and centering

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/ui/components/ExpressiveCarousel.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/components/ExpressiveCarousel.kt
@@ -76,7 +76,7 @@ fun ExpressiveHeroCarousel(
     val screenWidth = configuration.screenWidthDp.dp
     // Calculate item width to show one item with slight peek of next item
     val itemWidth = remember(screenWidth, horizontalPadding) {
-        screenWidth - (horizontalPadding * 2) + (pageSpacing * 2)
+        screenWidth - (horizontalPadding * 2)
     }
 
     val carouselState = rememberCarouselState { items.size }
@@ -227,6 +227,7 @@ private fun ExpressiveHeroCard(
 
             // ✅ Performance: Use drawWithCache for gradient to avoid recomposition
             val scrimColor = MaterialTheme.colorScheme.scrim
+            val overlayTextColor = MaterialTheme.colorScheme.onScrim
             Box(
                 modifier = Modifier
                     .fillMaxSize()
@@ -255,7 +256,7 @@ private fun ExpressiveHeroCard(
                     text = item.title,
                     style = MaterialTheme.typography.headlineMedium,
                     fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onSurface,
+                    color = overlayTextColor,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
                 )
@@ -264,7 +265,7 @@ private fun ExpressiveHeroCard(
                     Text(
                         text = item.subtitle,
                         style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.9f),
+                        color = overlayTextColor.copy(alpha = 0.9f),
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                         modifier = Modifier.padding(top = 4.dp),


### PR DESCRIPTION
### Motivation
- Overlay text on hero carousel images was hard to read in light mode and the carousel layout appeared off-center, so contrast and width calculation needed adjustment.

### Description
- Adjusted the item width calculation in `ExpressiveHeroCarousel` to `screenWidth - (horizontalPadding * 2)` to keep the carousel centered and switched the hero overlay text colors to use `MaterialTheme.colorScheme.onScrim` for the title and subtitle in `app/src/main/java/com/rpeters/jellyfin/ui/components/ExpressiveCarousel.kt` to improve contrast.

### Testing
- No automated tests were run in this environment (no `./gradlew testDebugUnitTest` or `./gradlew lintDebug` executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697851abbe8083279466c46e3a7d5300)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected carousel item width calculation for proper display spacing.

* **Style**
  * Standardized overlay text colors in carousel cards for visual consistency.
  * Applied uniform color treatment to carousel card titles and subtitles.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->