### PR TITLE
fix: improve carousel overlay contrast

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/home/HomeCarousel.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/home/HomeCarousel.kt
@@ -25,6 +25,9 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
@@ -104,6 +107,8 @@ private fun CarouselMovieCard(
         ),
     ) {
         Box(modifier = Modifier.fillMaxSize()) {
+            val scrimColor = MaterialTheme.colorScheme.scrim
+            val overlayTextColor = MaterialTheme.colorScheme.onScrim
             OptimizedImage(
                 imageUrl = getBackdropUrl(movie),
                 contentDescription = "${movie.name} backdrop",
@@ -112,6 +117,21 @@ private fun CarouselMovieCard(
                 quality = ImageQuality.HIGH,
                 contentScale = ContentScale.Crop,
                 cornerRadius = 16.dp,
+            )
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .drawWithCache {
+                        val gradient = Brush.verticalGradient(
+                            colors = listOf(
+                                Color.Transparent,
+                                scrimColor.copy(alpha = 0.75f),
+                            ),
+                            startY = size.height * 0.40f,
+                            endY = size.height,
+                        )
+                        onDrawBehind { drawRect(gradient) }
+                    },
             )
             movie.communityRating?.let { rating ->
                 Surface(
@@ -139,7 +159,7 @@ private fun CarouselMovieCard(
                 MaterialText(
                     text = movie.name ?: stringResource(R.string.unknown),
                     style = MaterialTheme.typography.titleLarge,
-                    color = MaterialTheme.colorScheme.onSurface,
+                    color = overlayTextColor,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
                     autoSize = true,
@@ -253,6 +273,8 @@ private fun CarouselContentCard(
                 BaseItemKind.SERIES -> getSeriesImageUrl(item) ?: getBackdropUrl(item) ?: getImageUrl(item)
                 else -> getBackdropUrl(item) ?: getImageUrl(item)
             }
+            val scrimColor = MaterialTheme.colorScheme.scrim
+            val overlayTextColor = MaterialTheme.colorScheme.onScrim
 
             OptimizedImage(
                 imageUrl = imageUrl,
@@ -262,6 +284,21 @@ private fun CarouselContentCard(
                 quality = ImageQuality.HIGH,
                 contentScale = ContentScale.Crop,
                 cornerRadius = 16.dp,
+            )
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .drawWithCache {
+                        val gradient = Brush.verticalGradient(
+                            colors = listOf(
+                                Color.Transparent,
+                                scrimColor.copy(alpha = 0.75f),
+                            ),
+                            startY = size.height * 0.40f,
+                            endY = size.height,
+                        )
+                        onDrawBehind { drawRect(gradient) }
+                    },
             )
 
             // Rating badge
@@ -293,7 +330,7 @@ private fun CarouselContentCard(
                 MaterialText(
                     text = item.name ?: stringResource(R.string.unknown),
                     style = MaterialTheme.typography.titleLarge,
-                    color = MaterialTheme.colorScheme.onSurface,
+                    color = overlayTextColor,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
                     autoSize = true,
@@ -308,7 +345,7 @@ private fun CarouselContentCard(
                             Text(
                                 text = seriesName,
                                 style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
+                                color = overlayTextColor.copy(alpha = 0.85f),
                                 maxLines = 1,
                             )
                         }
@@ -318,7 +355,7 @@ private fun CarouselContentCard(
                             Text(
                                 text = year.toString(),
                                 style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
+                                color = overlayTextColor.copy(alpha = 0.85f),
                                 maxLines = 1,
                             )
                         }
@@ -328,7 +365,7 @@ private fun CarouselContentCard(
                             Text(
                                 text = artist,
                                 style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
+                                color = overlayTextColor.copy(alpha = 0.85f),
                                 maxLines = 1,
                             )
                         }


### PR DESCRIPTION
### Motivation
- Carousel overlay text used `onSurface` with no scrim, making it unreadable over dark artwork in light mode.
- The goal is to provide a stable background behind overlay text and use the appropriate theme color so text is legible in both light and dark themes.

### Description
- Added imports for `drawWithCache`, `Brush`, and `Color` and introduced a vertical bottom scrim drawn over carousel images using `Brush.verticalGradient` in both `CarouselMovieCard` and `CarouselContentCard`.
- Read scrim color with `val scrimColor = MaterialTheme.colorScheme.scrim` and set overlay text color to `val overlayTextColor = MaterialTheme.colorScheme.onScrim`.
- Replaced `MaterialTheme.colorScheme.onSurface` uses for overlay title and secondary lines with `overlayTextColor` and adjusted alpha for secondary text to `0.85f`.
- Kept existing rating badge and other layout logic untouched so the change is focused on contrast/readability only.

### Testing
- No automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978ed2dd2d8832790fb9afeb2ea4253)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added gradient overlay effects to home carousel image cards for enhanced visual presentation
  * Improved text contrast and readability throughout carousel content by optimizing color usage over visual overlays
  * Refined text styling and layout positioning to maintain clear visual hierarchy in carousel sections

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->