### PR TITLE
fix: remove unused format placeholder from version string

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -66,7 +66,7 @@
     <string name="no_seasons_available">No seasons available</string>
     
     <!-- Profile -->
-    <string name="version">Version %1$s</string>
+    <string name="version">Version</string>
     <string name="unknown">Unknown</string>
     <string name="server">Server: %1$s</string>
     


### PR DESCRIPTION
### Motivation
- The UI showed a raw format placeholder (`%1$s`) for the version label because the `version` string resource contained an unused format token, so the label needs to be a plain "Version" with the actual value shown on the next line.

### Description
- Update `app/src/main/res/values/strings.xml` to change `<string name="version">Version %1$s</string>` to `<string name="version">Version</string>` so the label no longer includes a format placeholder.

### Testing
- No automated tests were run for this change; `./gradlew testDebugUnitTest` and `./gradlew lintDebug` were not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a3f548e308327bdabcf778003ad0a)