### PR TITLE
feat: improve profile info rows

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/ProfileScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/ProfileScreen.kt
@@ -1,5 +1,6 @@
 package com.rpeters.jellyfin.ui.screens
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -15,6 +16,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.Logout
 import androidx.compose.material.icons.filled.AccountBox
 import androidx.compose.material.icons.filled.Computer
+import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -30,8 +32,12 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.rpeters.jellyfin.OptInAppExperimentalApis
 import com.rpeters.jellyfin.R
@@ -49,6 +55,7 @@ fun ProfileScreen(
     showBackButton: Boolean = true,
     modifier: Modifier = Modifier,
 ) {
+    val uriHandler = LocalUriHandler.current
     Scaffold(
         topBar = {
             TopAppBar(
@@ -159,7 +166,15 @@ fun ProfileScreen(
 
                     currentServer?.let { server ->
                         ProfileInfoRow("Server Name", server.name)
-                        ProfileInfoRow("Server URL", server.url)
+                        ProfileInfoRow(
+                            label = "Server URL",
+                            value = server.url,
+                            onValueClick = if (server.url.startsWith("http")) {
+                                { uriHandler.openUri(server.url) }
+                            } else {
+                                null
+                            },
+                        )
                         ProfileInfoRow("User ID", server.userId ?: stringResource(id = R.string.unknown))
                     }
                 }
@@ -223,22 +238,50 @@ private fun ProfileInfoRow(
     label: String,
     value: String,
     modifier: Modifier = Modifier,
+    onValueClick: (() -> Unit)? = null,
 ) {
-    Row(
+    val clipboardManager = LocalClipboardManager.current
+    Column(
         modifier = modifier
             .fillMaxWidth()
             .padding(vertical = 4.dp),
-        horizontalArrangement = Arrangement.SpaceBetween,
     ) {
         Text(
             text = label,
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
         )
-        Text(
-            text = value,
-            style = MaterialTheme.typography.bodyMedium,
-            fontWeight = FontWeight.Medium,
-        )
+        Spacer(modifier = Modifier.height(6.dp))
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text(
+                text = value,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier
+                    .weight(1f)
+                    .then(
+                        if (onValueClick != null) {
+                            Modifier.clickable(onClick = onValueClick)
+                        } else {
+                            Modifier
+                        },
+                    ),
+            )
+            IconButton(
+                onClick = { clipboardManager.setText(AnnotatedString(value)) },
+            ) {
+                Icon(
+                    imageVector = Icons.Default.ContentCopy,
+                    contentDescription = stringResource(id = R.string.copy_value),
+                )
+            }
+        }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,6 +15,7 @@
     <string name="delete">Delete</string>
     <string name="edit">Edit</string>
     <string name="download">Download</string>
+    <string name="copy_value">Copy value</string>
     
     <!-- Screen Titles -->
     <string name="home">Home</string>


### PR DESCRIPTION
### Motivation
- Improve readability of profile entries (server URL, user ID) by stacking label/value and preventing overflow, and provide a quick copy action for values.
- Allow tapping the server URL to open it when it appears to be a valid link for faster navigation.

### Description
- Reworked `ProfileInfoRow` in `app/src/main/java/com/rpeters/jellyfin/ui/screens/ProfileScreen.kt` to use a stacked label/value layout with a secondary row containing the value and a trailing copy `IconButton`.
- Added `maxLines` and `overflow = TextOverflow.Ellipsis` to label and value to avoid layout breakage on long strings and used `Modifier.weight(1f)` so values wrap sensibly.
- Added optional `onValueClick` parameter to `ProfileInfoRow` and wire up `LocalUriHandler` to open the server URL when it starts with `http`.
- Use `LocalClipboardManager` and `AnnotatedString` to copy the value to clipboard when the copy icon is tapped, and added the `copy_value` string resource in `app/src/main/res/values/strings.xml`.
- Added required imports for clipboard, URI handler, `ContentCopy` icon, and text overflow handling.

### Testing
- No automated tests were run as part of this change (`./gradlew testDebugUnitTest` and `./gradlew lintDebug` were not executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a3f55fa7c8327a95d155a83bc74c0)