### PR TITLE
Poster card vertical uniformity

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/ui/components/MaterialText.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/components/MaterialText.kt
@@ -23,6 +23,7 @@ fun MaterialText(
     modifier: Modifier = Modifier,
     style: TextStyle = MaterialTheme.typography.bodyMedium,
     color: androidx.compose.ui.graphics.Color = androidx.compose.ui.graphics.Color.Unspecified,
+    minLines: Int = 1,
     maxLines: Int = Int.MAX_VALUE,
     overflow: TextOverflow = TextOverflow.Clip,
     autoSize: Boolean = false,
@@ -35,6 +36,7 @@ fun MaterialText(
             modifier = modifier,
             style = style,
             color = color,
+            minLines = minLines,
             maxLines = maxLines,
             overflow = overflow,
         )
@@ -53,6 +55,7 @@ fun MaterialText(
             text,
             constraints.maxWidth,
             style,
+            minLines,
             maxLines,
             minFontSize,
             resolvedMaxFontSize,
@@ -88,6 +91,7 @@ fun MaterialText(
             text = text,
             style = style.copy(fontSize = targetFontSize),
             color = color,
+            minLines = minLines,
             maxLines = maxLines,
             overflow = overflow,
         )

--- a/app/src/main/java/com/rpeters/jellyfin/ui/components/MediaCards.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/components/MediaCards.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -311,6 +312,7 @@ fun PosterMediaCard(
     enhancedPlaybackUtils: com.rpeters.jellyfin.ui.utils.EnhancedPlaybackUtils? = null,
     showTitle: Boolean = true,
     showMetadata: Boolean = true,
+    titleMinLines: Int = 1,
     cardWidth: Dp? = null, // Made optional - null means fill available width
 ) {
     val contentTypeColor = getContentTypeColor(item.type.toString())
@@ -474,6 +476,7 @@ fun PosterMediaCard(
                         MaterialText(
                             text = item.name ?: stringResource(R.string.unknown),
                             style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Medium),
+                            minLines = titleMinLines,
                             maxLines = 2,
                             overflow = TextOverflow.Ellipsis,
                             color = MaterialTheme.colorScheme.onSurface,
@@ -487,6 +490,7 @@ fun PosterMediaCard(
 
                     if (showMetadata) {
                         Row(
+                            modifier = Modifier.heightIn(min = 24.dp),
                             horizontalArrangement = Arrangement.spacedBy(8.dp),
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
@@ -697,6 +701,7 @@ fun RecentlyAddedCard(
                 MaterialText(
                     text = item.name ?: stringResource(R.string.unknown),
                     style = MaterialTheme.typography.bodyMedium,
+                    minLines = 2,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
                     color = MaterialTheme.colorScheme.onSurface,
@@ -708,6 +713,7 @@ fun RecentlyAddedCard(
                 Spacer(modifier = Modifier.height(4.dp))
 
                 Row(
+                    modifier = Modifier.heightIn(min = 24.dp),
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/HomeScreen.kt
@@ -874,17 +874,17 @@ private fun ContinueWatchingCard(
                     overflow = TextOverflow.Ellipsis,
                 )
 
-                if (item.type == BaseItemKind.EPISODE) {
-                    Text(
-                        text = buildString {
-                            item.seriesName?.let { append(it) }
-                        },
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                }
+                // Reserve a consistent second text line to avoid LazyRow height "jumping"
+                // when episode cards (which show series name) scroll into view.
+                val seriesName = if (item.type == BaseItemKind.EPISODE) item.seriesName.orEmpty() else ""
+                Text(
+                    text = seriesName,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    minLines = 1,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
 
                 Text(
                     text = "${watchedPercentage.roundToInt()}% watched",
@@ -924,6 +924,7 @@ private fun PosterRowSection(
                 cardWidth = cardWidth,
                 showTitle = true,
                 showMetadata = true,
+                titleMinLines = 2,
             )
         }
     }

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/TVSeasonScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/TVSeasonScreen.kt
@@ -1166,6 +1166,7 @@ private fun MoreLikeThisSection(
                         getImageUrl = getImageUrl,
                         onClick = { onSeriesClick(show.id.toString()) },
                         showMetadata = false,
+                        titleMinLines = 2,
                         cardWidth = 140.dp,
                     )
                 }


### PR DESCRIPTION
## Summary

This PR resolves vertical UI jumping in horizontal card carousels by ensuring uniform card heights. It achieves this by:
*   Reserving fixed line counts for titles in `PosterMediaCard` and `RecentlyAddedCard`.
*   Enforcing a minimum height for metadata sections in `PosterMediaCard` and `RecentlyAddedCard`.
*   Always reserving a second line for the series name in `ContinueWatchingCard`, even for non-episode items.

This prevents the layout from shifting as cards with varying text lengths or missing metadata scroll into view.

## Type of change

- [x] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no functional change)
- [ ] perf (performance improvement)
- [ ] test (add/fix tests)
- [ ] chore (build, tooling, deps)

## Screenshots/GIFs (UI changes)

<!-- If UI changed, add before/after screenshots or a short GIF. -->

## How to test

```bash
# Build
./gradlew assembleDebug

# Unit tests
./gradlew testDebugUnitTest

# Lint
./gradlew lintDebug

# Coverage (HTML under app/build/reports)
./gradlew jacocoTestReport
```

## Checklist

- [x] Follows Conventional Commits
- [x] Branch named appropriately (feature/..., bugfix/..., hotfix/..., docs/...)
- [ ] Tests added/updated where applicable
- [ ] `./gradlew testDebugUnitTest` passes
- [x] `./gradlew lintDebug` passes
- [ ] Docs updated (README/CHANGELOG as needed)
- [x] Affected areas and testing notes included

---
<a href="https://cursor.com/background-agent?bcId=bc-1e6bb76d-e325-42d0-9fb7-a9059d815dcc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1e6bb76d-e325-42d0-9fb7-a9059d815dcc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

