### PR TITLE
refactor: unify ExoPlayer setup and expand Media3 alpha audit

### DIFF
--- a/docs/development/media3-alpha-changelog-audit.md
+++ b/docs/development/media3-alpha-changelog-audit.md
@@ -1,0 +1,120 @@
+# Media3 latest alpha changelog audit for Jellyfin Android
+
+This document maps the latest Media3 alpha changelog items to the current Jellyfin Android codebase.
+
+## Current baseline
+
+- The app is pinned to `androidx.media3` `1.10.0-alpha01`.
+- Core modules in use: ExoPlayer (`exoplayer`, `hls`, `dash`), `common`, `ui`, `session`, `cast`, and `datasource-okhttp`.
+
+## What we should improve now (high value / low risk)
+
+### 1) Enable dynamic video scheduling experiment in `DefaultRenderersFactory`
+
+**Changelog item:** `experimentalSetEnableMediaCodecVideoRendererDurationToProgressUs()`.
+
+**Why it matters here:**
+- We build `DefaultRenderersFactory` in two playback setup paths and rely on software/hardware fallback behavior.
+- This is exactly where the new scheduling optimization is configured.
+
+**Recommendation:**
+- Ensure the opt-in is applied identically in both ExoPlayer builder paths in `VideoPlayerViewModel` (around the two existing init blocks).
+- Keep this behind a local flag and shared helper to avoid one-path-only behavior.
+
+### 2) Cast: add track selector to `RemoteCastPlayer`
+
+**Changelog item:** `RemoteCastPlayer.Builder#setTrackSelector(...)`.
+
+**Why it matters here:**
+- We already have custom cast orchestration (`CastManager`) and local track state handling (`TrackSelectionManager`).
+- This API gives us a path to align Cast audio/subtitle behavior with local preferences rather than receiver defaults.
+
+**Recommendation:**
+- Add to near-term backlog (do now/low risk if cast stack changes are isolated; do next/medium if staged).
+- Implement a Cast track selector bridge so preferred audio/subtitle tracks are applied consistently for Cast playback.
+
+### 3) Adopt new compose speed/progress controls selectively
+
+**Changelog items:** `PlaybackSpeedControl`, `PlaybackSpeedToggleButton`, `ProgressSlider`.
+
+**Why it matters here:**
+- We have custom controls for phone/TV. The new composables could reduce maintenance cost where our controls are basic.
+
+**Recommendation:**
+- No urgent migration required.
+- Evaluate only for screens where parity with Material3 behavior and accessibility is desired.
+
+### 4) Validate AC-4/IAMF behavior on Automotive & Spatializer-capable devices
+
+**Changelog items:** AC-4 profile handling fix and IAMF decoder/spatialization updates.
+
+**Why it matters here:**
+- We support mixed codecs and transcoding fallback; device-specific codec capability changes can alter direct play vs transcode decisions.
+
+**Recommendation:**
+- Add/extend playback capability QA matrix for Automotive-like environments and spatial audio devices.
+
+## Benefits we already get from alpha01
+
+### ProgressiveMediaSource timeline/queue fix (relevant to offline playback)
+
+**Changelog item:** ProgressiveMediaSource stale timeline propagation fix (#3016).
+
+**Why it matters here:**
+- `OfflinePlaybackManager` uses `ProgressiveMediaSource` for local file playback.
+- This fix reduces risk of queued periods being removed unexpectedly in progressive/offline flows.
+
+## Changes we likely need if we upgrade beyond current alpha
+
+### 1) Session custom notification provider API drift (potential breakage)
+
+**Changelog item:** stale foreground-service `Intent` detection added; **breaking change on unstable API** for apps implementing custom `MediaNotification.Provider`.
+
+**Current implementation:**
+- `AudioService` currently uses `DefaultMediaNotificationProvider`, not a custom provider implementation.
+
+**Impact:**
+- Low immediate risk.
+- If we later switch to a custom provider, we must implement the new required method at the same time.
+
+### 2) Inspector module split (`FrameExtractor` removal)
+
+**Changelog item:** `FrameExtractor` removed from old package, moved to `:media3-inspector-frame`.
+
+**Current implementation:**
+- No `FrameExtractor` usage found in app source.
+
+### 3) Effect Lottie module split
+
+**Changelog item:** `LottieOverlay` moved to `:media3-effect-lottie` with package rename.
+
+**Current implementation:**
+- No `LottieOverlay` usage found in app source.
+
+### 4) Removed deprecated symbols (`ExperimentalFrameExtractor`, `ChannelMixingMatrix.create()`)
+
+**Current implementation:**
+- No usages found for these removed APIs.
+
+## Changelog items that are not currently relevant to our implementation
+
+- `AdsMediaSource` clipping: not using Media3 ad media source pipelines in app playback path.
+- `DefaultPreloadManager.Builder` custom `DataSource.Factory`: not using preload manager.
+- `CompositionPlayer` / `Transformer` edited media features: not used for local editing/export workflows.
+- IMA extension additions: no IMA extension dependency in current build.
+
+## Concrete code-level next steps
+
+1. Ensure the dynamic renderer scheduling opt-in is applied identically in both ExoPlayer builder paths in `VideoPlayerViewModel`, via shared helper(s).
+2. Unify ExoPlayer creation into a single factory/helper method so renderer flags + track selector + source-factory differences are explicit and testable.
+3. Add Cast track selector integration plan using `RemoteCastPlayer.Builder#setTrackSelector(...)` to mirror local audio/subtitle preferences on Cast sessions.
+4. Keep `MediaSessionService` implementation as-is for now; revisit only if we introduce custom media notification provider logic.
+5. Keep watcher checks for removed/moved APIs in dependency bump PR template.
+6. Add one regression test pass for playback startup latency + dropped frames after enabling dynamic scheduling experiment.
+
+## Priority summary
+
+- **Do now:** dynamic scheduling helper parity across both ExoPlayer paths + single ExoPlayer factory helper.
+- **Do next (medium):** Cast track selector integration for receiver audio/subtitle consistency.
+- **Do on next media3 bump:** validate session-notification unstable API changes and rerun codec capability QA.
+- **No-op currently:** inspector/effect/IMA-specific migrations unless those modules are introduced.


### PR DESCRIPTION
### Motivation
- Reduce drift between the two ExoPlayer initialization paths and make renderer/track-selector flags explicit and testable. 
- Opt into Media3’s dynamic video scheduling experiment in a safe, centralized way to avoid path-specific behavior. 
- Surface two high-value Media3 alpha items in the audit: Cast track selection via `RemoteCastPlayer.Builder#setTrackSelector(...)` and the `ProgressiveMediaSource` timeline/queue fix relevant to offline/progressive playback.

### Description
- Centralized ExoPlayer construction in `VideoPlayerViewModel` by adding `createAdaptiveTrackSelector()`, `createExoPlayer(...)`, and reusing the existing `createRenderersFactory()` so both player-init paths call the same helpers (file: `app/src/main/java/com/rpeters/jellyfin/ui/player/VideoPlayerViewModel.kt`).
- Kept renderer configuration (`EXTENSION_RENDERER_MODE_ON`, decoder fallback) and added a guarded opt-in for the dynamic scheduling experiment in `createRenderersFactory()` using `experimentalSetEnableMediaCodecVideoRendererDurationToProgressUs(true)` wrapped in a `try/catch NoSuchMethodError` so it is safe across Media3 versions. 
- Updated the Media3 audit doc (`docs/development/media3-alpha-changelog-audit.md`) to include a new section recommending adding a Cast track selector bridge (`RemoteCastPlayer.Builder#setTrackSelector(...)`) and to call out the `ProgressiveMediaSource` timeline/queue fix as a benefit for `OfflinePlaybackManager` usage. 
- Replaced inline `DefaultTrackSelector`/`ExoPlayer.Builder` usages with the new helpers to ensure consistent behavior across both playback code paths.

### Testing
- Attempted to compile Kotlin sources with `./gradlew :app:compileDebugKotlin -q` to validate the changes; the build failed in this environment because the Android Gradle plugin `com.android.application:9.0.0` could not be resolved from configured repositories, so compilation could not be validated. 
- No unit or instrumentation tests were executed in this environment due to the repository/plugin resolution failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a1a46be648327989af4c310e1012f)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core playback initialization and renderer configuration, so regressions could affect startup, track selection, or device-specific decoding despite the change being mostly refactor + guarded opt-in.
> 
> **Overview**
> Refactors `VideoPlayerViewModel` to **unify ExoPlayer initialization** across both playback setup paths by introducing shared helpers for the adaptive `DefaultTrackSelector`, `ExoPlayer` builder, and renderer factory.
> 
> Adds an opt-in (behind a local flag) for Media3’s **dynamic video scheduling experiment** via `DefaultRenderersFactory.experimentalSetEnableMediaCodecVideoRendererDurationToProgressUs(true)`, guarded with `NoSuchMethodError` handling for compatibility.
> 
> Introduces a new `docs/development/media3-alpha-changelog-audit.md` documenting current Media3 alpha baseline and calling out near-term items (dynamic scheduling, potential Cast track selector bridging, and offline `ProgressiveMediaSource` fix) for future work.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d32d2538c8db99ba1638f0ed8c7d704c270a0b40. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Frpeters1430%2FJellyfinAndroid%2Fpull%2F794&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->