### PR TITLE
Add `.gemini/commands` scaffold for TOML command files

### DIFF
--- a/.gemini/commands/.gitkeep
+++ b/.gemini/commands/.gitkeep
@@ -1,0 +1,1 @@
+# Keep this directory in git for Gemini command TOML files.

--- a/.gitignore
+++ b/.gitignore
@@ -101,7 +101,8 @@ Desktop.ini
 .aider*
 
 # Gemini CLI
-.gemini/
+.gemini/*
 !.gemini/commands/
+!.gemini/commands/**
 .gemini/telemetry.log
 gha-creds-*.json


### PR DESCRIPTION
### Motivation
- Provide a tracked `./.gemini/commands/` directory so TOML command files can be added while keeping `.gemini` ignored by default.

### Description
- Added `.gemini/commands/.gitkeep` placeholder with a short comment so the directory is tracked.
- Updated `.gitignore` to change the `.gemini` rule to `/.gemini/*` and explicitly allow `!.gemini/commands/` and `!.gemini/commands/**` while keeping `.gemini/telemetry.log` ignored.

### Testing
- Verified `test -d .gemini/commands` succeeded.
- Verified `git check-ignore .gemini/commands/example.toml` returned not ignored.
- Verified `git check-ignore .gemini/telemetry.log` returned ignored.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b62ae25f88327adcd6d99b86e3722)