### PR TITLE
fix: enforce selected offline download quality and show episode file size

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/data/repository/JellyfinRepository.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/data/repository/JellyfinRepository.kt
@@ -1025,6 +1025,7 @@ class JellyfinRepository @Inject constructor(
         container: String = DEFAULT_CONTAINER,
         audioBitrate: Int? = null,
         audioChannels: Int = DEFAULT_MAX_AUDIO_CHANNELS,
+        allowVideoStreamCopy: Boolean = true,
     ): String? =
         streamRepository.getTranscodedStreamUrl(
             itemId = itemId,
@@ -1036,6 +1037,7 @@ class JellyfinRepository @Inject constructor(
             container = container,
             audioBitrate = audioBitrate,
             audioChannels = audioChannels,
+            allowVideoStreamCopy = allowVideoStreamCopy,
         )
 
     fun getHlsStreamUrl(itemId: String): String? =

--- a/app/src/main/java/com/rpeters/jellyfin/data/repository/JellyfinStreamRepository.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/data/repository/JellyfinStreamRepository.kt
@@ -206,6 +206,7 @@ class JellyfinStreamRepository @Inject constructor(
         subtitleStreamIndex: Int? = null,
         audioChannels: Int = DEFAULT_MAX_AUDIO_CHANNELS,
         audioBitrate: Int? = null,
+        allowVideoStreamCopy: Boolean = true,
         allowAudioStreamCopy: Boolean = true,
     ): String? {
         val server = authRepository.getCurrentServer() ?: return null
@@ -246,7 +247,7 @@ class JellyfinStreamRepository @Inject constructor(
             params.add("DeviceId=${deviceCapabilities.getDeviceId()}")
             params.add("BreakOnNonKeyFrames=true")
             // Allow Direct Stream - keep video quality, only transcode audio if needed
-            params.add("AllowVideoStreamCopy=true")
+            params.add("AllowVideoStreamCopy=$allowVideoStreamCopy")
             params.add("AllowAudioStreamCopy=$allowAudioStreamCopy")
 
             // Add stream indices for multilingual content

--- a/app/src/main/java/com/rpeters/jellyfin/ui/downloads/DownloadsViewModel.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/downloads/DownloadsViewModel.kt
@@ -132,6 +132,7 @@ class DownloadsViewModel @Inject constructor(
                         audioBitrate = selectedQuality.audioBitrate,
                         audioChannels = selectedQuality.audioChannels ?: 2,
                         container = "mp4",
+                        allowVideoStreamCopy = false,
                     ) ?: repository.getDownloadUrl(itemId)
                 } else {
                     downloadUrl ?: repository.getDownloadUrl(itemId)

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/ImmersiveTVEpisodeDetailScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/ImmersiveTVEpisodeDetailScreen.kt
@@ -669,32 +669,44 @@ private fun EpisodeOverviewSection(
                     }
                 }
 
-                // Air Date & Runtime (MM - DD - YYYY)
-                Row(
+                // Air Date, Runtime, File Size
+                Column(
                     modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(16.dp),
-                    verticalAlignment = Alignment.CenterVertically,
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
                 ) {
-                    episode.premiereDate?.let { date ->
-                        // Input format is typically 2024-01-23T00:00:00Z
-                        val dateStr = date.toString().substringBefore('T')
-                        val parts = dateStr.split("-")
-                        if (parts.size == 3) {
-                            val formattedDate = "${parts[1]} - ${parts[2]} - ${parts[0]}" // MM - DD - YYYY
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(16.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        episode.premiereDate?.let { date ->
+                            // Input format is typically 2024-01-23T00:00:00Z
+                            val dateStr = date.toString().substringBefore('T')
+                            val parts = dateStr.split("-")
+                            if (parts.size == 3) {
+                                val formattedDate = "${parts[1]} - ${parts[2]} - ${parts[0]}" // MM - DD - YYYY
+                                DetailInfoRow(
+                                    label = "Aired",
+                                    value = formattedDate,
+                                    modifier = Modifier.weight(1f),
+                                )
+                            }
+                        }
+
+                        episode.runTimeTicks?.let { ticks ->
+                            val minutes = (ticks / 10_000_000 / 60).toInt()
                             DetailInfoRow(
-                                label = "Aired",
-                                value = formattedDate,
+                                label = "Duration",
+                                value = "${minutes}m",
                                 modifier = Modifier.weight(1f),
                             )
                         }
                     }
 
-                    episode.runTimeTicks?.let { ticks ->
-                        val minutes = (ticks / 10_000_000 / 60).toInt()
+                    episode.mediaSources?.firstOrNull()?.size?.takeIf { it > 0 }?.let { fileSizeBytes ->
                         DetailInfoRow(
-                            label = "Duration",
-                            value = "${minutes}m",
-                            modifier = Modifier.weight(1f),
+                            label = "File Size",
+                            value = formatFileSize(fileSizeBytes),
                         )
                     }
                 }
@@ -765,6 +777,23 @@ private fun DetailInfoRow(
             overflow = TextOverflow.Ellipsis,
             textAlign = TextAlign.End,
         )
+    }
+}
+
+private fun formatFileSize(bytes: Long): String {
+    val units = listOf("B", "KB", "MB", "GB", "TB")
+    var size = bytes.toDouble()
+    var unitIndex = 0
+
+    while (size >= 1024 && unitIndex < units.lastIndex) {
+        size /= 1024
+        unitIndex++
+    }
+
+    return if (unitIndex == 0) {
+        "${size.toInt()} ${units[unitIndex]}"
+    } else {
+        String.format(Locale.US, "%.2f %s", size, units[unitIndex])
     }
 }
 


### PR DESCRIPTION
### Motivation
- Ensure that selecting a non-original download quality (e.g. 720p) actually results in a transcoded/downsized download instead of the server copying the original video stream.
- Surface the file size on the TV Episode detail screen so users can verify expected download size before starting offline downloads.

### Description
- Threaded a new `allowVideoStreamCopy` parameter through `JellyfinStreamRepository.getTranscodedStreamUrl` and `JellyfinRepository.getTranscodedStreamUrl` so callers can control whether the server is allowed to copy the original video stream or must transcode.
- In the offline download flow (`DownloadsViewModel.startDownload`) set `allowVideoStreamCopy = false` for non-`original` quality presets to force server-side transcoding at the requested bitrate/resolution.
- Added a `File Size` row to the TV Episode detail UI (`ImmersiveTVEpisodeDetailScreen`) that reads `mediaSources.firstOrNull()?.size` and formats it with a new `formatFileSize` helper for human-readable units.
- Changes touch the following files: `DownloadsViewModel.kt`, `JellyfinRepository.kt`, `JellyfinStreamRepository.kt`, and `ImmersiveTVEpisodeDetailScreen.kt`.

### Testing
- Attempted to compile the app with `./gradlew :app:compileDebugKotlin` to validate Kotlin changes, but the build failed in this environment due to the Android Gradle plugin `com.android.application` (version `9.0.1`) not being resolvable from configured repositories, so a full compile/run could not be completed here.
- No unit/instrumentation tests were added; behavior can be validated on-device/emulator by selecting a non-original quality (e.g. 720p) and verifying the generated transcoding URL includes `AllowVideoStreamCopy=false` and that the episode detail shows the file size value.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c93ee57b08327be76369116524432)