### PR TITLE
docs(cast): reconcile docs with implementation (auth note, remove duplicate header, deprecate old plan)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,7 +160,7 @@ The Cast system is split into dedicated controllers in `ui/player/cast/`:
   - **Why not Jellyfin's official receiver?** The Jellyfin Cast receivers (`F007D354` stable, `6F511C87` unstable) require implementing the full Jellyfin Cast protocol with custom data payloads containing server info, authentication, and media source selection. This app uses a simplified URL-based approach - sending HLS transcoded stream URLs with auth tokens as query parameters - which works reliably with Google's Default Media Receiver without requiring custom protocol implementation.
   - Source: https://github.com/jellyfin/jellyfin-chromecast
 - **Cast preferences**: Stored via `CastPreferencesRepository` for auto-reconnect
-- **Authentication**: Cast URLs no longer include tokens; casting protected media requires a local proxy or unauthenticated endpoint
+- **Authentication**: Cast URLs currently include `api_key` query parameters for receiver playback compatibility; this works for many setups but may still fail on hardened/auth-restricted deployments without a cast-safe proxy/token strategy
 - **Stream optimization**: Prefers HLS transcoding (`container=hls`) for maximum compatibility with adaptive streaming fallback
 - **Feature flag**: `ENABLE_CAST_FIX_PATH` gates cast reliability fixes for gradual rollout
 

--- a/docs/features/CAST_SYSTEM_UNIFIED_PLAN.md
+++ b/docs/features/CAST_SYSTEM_UNIFIED_PLAN.md
@@ -5,9 +5,6 @@
 **Replaces:**
 - `docs/features/CAST_REBUILD_SUMMARY.md`
 - `docs/features/CAST_ISSUE_TEMPLATE.md`
-**Replaces:**
-- `docs/features/CAST_REBUILD_SUMMARY.md`
-- `docs/features/CAST_ISSUE_TEMPLATE.md`
 - `docs/features/CAST_IMPLEMENTATION_STATUS_REVIEW_2026-02-23.md`
 - `docs/plans/CHROMECAST_REBUILD_PLAN.md`
 

--- a/docs/plans/CHROMECAST_REBUILD_PLAN.md
+++ b/docs/plans/CHROMECAST_REBUILD_PLAN.md
@@ -1,3 +1,6 @@
+> [!WARNING]
+> This document is **deprecated** and kept for historical context only. Use `docs/features/CAST_SYSTEM_UNIFIED_PLAN.md` as the canonical Cast plan.
+
 # Chromecast System Rebuild - Detailed Implementation Plan
 
 ## Executive Summary


### PR DESCRIPTION
### Motivation
- Reconcile documentation with the actual Cast implementation so readers and contributors have accurate guidance about authentication and plan ownership.
- Remove a duplicated header in the unified Cast plan to avoid confusion and mark the older rebuild plan as deprecated to direct work toward the canonical plan.

### Description
- Clarified the Cast authentication note in `CLAUDE.md` to state the implementation currently appends an `api_key` query parameter for receiver playback and noted limitations for hardened deployments that may require a proxy or alternate strategy.
- Removed a duplicated `Replaces` block from `docs/features/CAST_SYSTEM_UNIFIED_PLAN.md` to tidy the document structure.
- Added a deprecation warning banner to `docs/plans/CHROMECAST_REBUILD_PLAN.md` so the detailed rebuild plan is preserved for history but points readers to the unified canonical plan.

### Testing
- Ran repository searches with `rg` to confirm `CastOptionsProvider` manifest wiring and cast-related dependencies were present and that the Cast load path still propagates `playSessionId`/`mediaSourceId` into custom data. These checks succeeded.
- Attempted to run targeted unit tests with `./gradlew testDebugUnitTest --tests "com.rpeters.jellyfin.ui.player.CastManagerTest" --tests "com.rpeters.jellyfin.ui.player.CastMediaLoadBuilderTest"`, which failed early in this environment due to AGP resolution error for `com.android.application:9.0.1`. No unit tests were executed to completion because of that failure.
- Confirmed the modified documentation files are syntactically updated and the repository now contains the edited docs files for review.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699de83e052c8327b56184a0a77722dc)