### PR TITLE
Fix PagingSource offset math to stop intermittent missing library items

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/data/paging/LibraryItemPagingSource.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/data/paging/LibraryItemPagingSource.kt
@@ -23,16 +23,15 @@ class LibraryItemPagingSource(
 
     companion object {
         private const val TAG = "LibraryItemPagingSource"
-        private const val STARTING_PAGE_INDEX = 0
+        private const val STARTING_START_INDEX = 0
     }
 
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, BaseItemDto> {
         return try {
-            val pageIndex = params.key ?: STARTING_PAGE_INDEX
-            val startIndex = pageIndex * pageSize
+            val startIndex = params.key ?: STARTING_START_INDEX
 
             if (BuildConfig.DEBUG) {
-                Log.d(TAG, "Loading page $pageIndex, startIndex=$startIndex, loadSize=${params.loadSize}")
+                Log.d(TAG, "Loading startIndex=$startIndex, loadSize=${params.loadSize}")
             }
 
             val itemTypesString = itemTypes?.joinToString(",") { type ->
@@ -62,18 +61,30 @@ class LibraryItemPagingSource(
                     val items = result.data
 
                     if (BuildConfig.DEBUG) {
-                        Log.d(TAG, "Loaded ${items.size} items for page $pageIndex")
+                        Log.d(TAG, "Loaded ${items.size} items for startIndex=$startIndex")
+                    }
+
+                    val previousKey = if (startIndex == STARTING_START_INDEX) {
+                        null
+                    } else {
+                        maxOf(STARTING_START_INDEX, startIndex - params.loadSize)
+                    }
+
+                    val nextKey = if (items.isEmpty() || items.size < params.loadSize) {
+                        null
+                    } else {
+                        startIndex + items.size
                     }
 
                     LoadResult.Page(
                         data = items,
-                        prevKey = if (pageIndex == STARTING_PAGE_INDEX) null else pageIndex - 1,
-                        nextKey = if (items.isEmpty() || items.size < params.loadSize) null else pageIndex + 1,
+                        prevKey = previousKey,
+                        nextKey = nextKey,
                     )
                 }
                 is ApiResult.Error -> {
                     if (BuildConfig.DEBUG) {
-                        Log.w(TAG, "Failed to load page $pageIndex: ${result.message}")
+                        Log.w(TAG, "Failed to load startIndex=$startIndex: ${result.message}")
                     }
                     LoadResult.Error(Exception(result.message))
                 }
@@ -97,7 +108,8 @@ class LibraryItemPagingSource(
         //    just return null.
         return state.anchorPosition?.let { anchorPosition ->
             val anchorPage = state.closestPageToPosition(anchorPosition)
-            anchorPage?.prevKey?.plus(1) ?: anchorPage?.nextKey?.minus(1)
+            anchorPage?.prevKey?.plus(anchorPage.data.size)
+                ?: anchorPage?.nextKey?.minus(pageSize)
         }
     }
 }

--- a/app/src/test/java/com/rpeters/jellyfin/data/paging/LibraryItemPagingSourceTest.kt
+++ b/app/src/test/java/com/rpeters/jellyfin/data/paging/LibraryItemPagingSourceTest.kt
@@ -75,7 +75,7 @@ class LibraryItemPagingSourceTest {
         assertEquals("Movie 1", pageResult.data[0].name)
         assertEquals("Movie 2", pageResult.data[1].name)
         assertNull(pageResult.prevKey)
-        assertEquals(1, pageResult.nextKey)
+        assertNull(pageResult.nextKey)
     }
 
     @Test
@@ -129,7 +129,7 @@ class LibraryItemPagingSourceTest {
         // When
         val result = pagingSource.load(
             PagingSource.LoadParams.Append(
-                key = 1,
+                key = 20,
                 loadSize = 20,
                 placeholdersEnabled = false,
             ),
@@ -139,8 +139,8 @@ class LibraryItemPagingSourceTest {
         assertTrue(result is PagingSource.LoadResult.Page<Int, BaseItemDto>)
         val pageResult = result as PagingSource.LoadResult.Page<Int, BaseItemDto>
         assertEquals(20, pageResult.data.size)
-        assertEquals(0, pageResult.prevKey) // Previous page key
-        assertEquals(2, pageResult.nextKey) // Next page key
+        assertEquals(0, pageResult.prevKey) // Previous start index
+        assertEquals(40, pageResult.nextKey) // Next start index
     }
 
     @Test
@@ -243,7 +243,7 @@ class LibraryItemPagingSourceTest {
         val pageResult = result as PagingSource.LoadResult.Page<Int, BaseItemDto>
         assertEquals(1, pageResult.data.size)
         assertNull(pageResult.prevKey) // First page
-        assertEquals(1, pageResult.nextKey)
+        assertNull(pageResult.nextKey)
     }
 
     @Test
@@ -253,7 +253,8 @@ class LibraryItemPagingSourceTest {
             coEvery { anchorPosition } returns 25 // Item at position 25
             coEvery { closestPageToPosition(25) } returns mockk {
                 coEvery { prevKey } returns 0
-                coEvery { nextKey } returns 2
+                coEvery { data } returns List(20) { mockk<BaseItemDto>() }
+                coEvery { nextKey } returns 40
             }
         }
 
@@ -261,7 +262,7 @@ class LibraryItemPagingSourceTest {
         val refreshKey = pagingSource.getRefreshKey(mockState)
 
         // Then
-        assertEquals(1, refreshKey) // prevKey + 1
+        assertEquals(20, refreshKey) // prevKey + page size
     }
 
     @Test


### PR DESCRIPTION
### Motivation
- Intermittent library items missing in A–Z lists were caused by Paging 3 requests using page-index math (`pageIndex * pageSize`) while `params.loadSize` can vary, producing overlapping/skipped windows and nondeterministic results.
- The change aims to make the paging pipeline request contiguous, offset-based windows so items are not skipped or duplicated.

### Description
- Changed `LibraryItemPagingSource` to use absolute `startIndex` keys instead of page indices, so `params.key` represents the API `startIndex` directly and requests use `limit = params.loadSize`.
- Replaced page-index logging and math with offset-based logging and computed `prevKey`/`nextKey` as offsets (`prevKey = max(0, startIndex - params.loadSize)` and `nextKey = startIndex + items.size` when appropriate).
- Updated `getRefreshKey` to compute a refresh offset consistent with offset-based keys instead of assuming page-number increments.
- Updated unit tests in `LibraryItemPagingSourceTest` to expect offset-style keys (e.g. `key = 20`, `nextKey = 40`) and to validate new end-of-data conditions.
- Files changed: `app/src/main/java/com/rpeters/jellyfin/data/paging/LibraryItemPagingSource.kt` and `app/src/test/java/com/rpeters/jellyfin/data/paging/LibraryItemPagingSourceTest.kt`.

### Testing
- Ran the unit test task: `./gradlew testDebugUnitTest --tests com.rpeters.jellyfin.data.paging.LibraryItemPagingSourceTest` and it failed in this environment because Gradle could not resolve the Android plugin `com.android.application` version `9.1.0` from configured repositories.
- Unit tests were updated to reflect the offset-key behavior, but full automated execution could not be completed here due to the Gradle plugin resolution failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a71f55456c832784ac9fae99bda11d)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Paging 3 key/offset math for library browsing; mistakes could still cause skipped/duplicated items or odd refresh behavior, but scope is limited and covered by updated unit tests.
> 
> **Overview**
> Fixes intermittent missing/duplicated library items by switching `LibraryItemPagingSource` from page-index keys to **absolute `startIndex` offset keys** (so requests always fetch contiguous windows even when `params.loadSize` varies).
> 
> Updates `prevKey`/`nextKey` and `getRefreshKey` calculations to operate on offsets, adjusts debug logging accordingly, and updates `LibraryItemPagingSourceTest` expectations (e.g., append keys like `20` -> next `40`, and end-of-data returning `null` `nextKey`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ac2f3e7b52a7cc4c74662fb5684ef24f01353f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->