### PR TITLE
Limit on-device Gemini Nano to Pixel devices to stabilize AI backend

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/data/ai/HybridAiTextModel.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/data/ai/HybridAiTextModel.kt
@@ -1,5 +1,6 @@
 package com.rpeters.jellyfin.data.ai
 
+import android.os.Build
 import android.util.Log
 import com.rpeters.jellyfin.data.repository.RemoteConfigRepository
 import kotlinx.coroutines.flow.Flow
@@ -36,7 +37,7 @@ class HybridAiTextModel(
      * Checks if Nano is available and starts download if necessary.
      */
     suspend fun initialize() {
-        if (remoteConfig.getBoolean("enable_on_device_ai")) {
+        if (shouldUseOnDeviceAi()) {
             try {
                 nanoModel.initialize()
                 updateActiveState()
@@ -44,7 +45,10 @@ class HybridAiTextModel(
                 Log.e("HybridAi", "[$label] Nano initialization failed: ${e.message}")
             }
         } else {
-            Log.d("HybridAi", "[$label] On-Device AI disabled via Remote Config")
+            Log.d(
+                "HybridAi",
+                "[$label] On-Device AI disabled (remoteConfig=${remoteConfig.getBoolean("enable_on_device_ai")}, supportedDevice=${isOnDeviceAiDeviceSupported()})",
+            )
         }
     }
 
@@ -52,6 +56,10 @@ class HybridAiTextModel(
      * Manually triggers a download retry.
      */
     suspend fun retryDownload() {
+        if (!shouldUseOnDeviceAi()) {
+            Log.d("HybridAi", "[$label] Skipping Nano retry on unsupported/disabled device")
+            return
+        }
         circuitBroken = false
         failureCount.set(0)
         nanoModel.downloadModel()
@@ -60,8 +68,30 @@ class HybridAiTextModel(
 
     private fun updateActiveState() {
         _isNanoActive.value = !circuitBroken && 
-            remoteConfig.getBoolean("enable_on_device_ai") &&
+            shouldUseOnDeviceAi() &&
             nanoModel.downloadState.value == AiDownloadState.READY
+    }
+
+    private fun shouldUseOnDeviceAi(): Boolean {
+        return remoteConfig.getBoolean("enable_on_device_ai") && isOnDeviceAiDeviceSupported()
+    }
+
+    /**
+     * Gemini Nano via ML Kit is currently flaky on many non-Pixel devices.
+     * Restrict on-device usage to Pixel devices for consistent behavior.
+     */
+    private fun isOnDeviceAiDeviceSupported(): Boolean {
+        val manufacturer = Build.MANUFACTURER
+        val model = Build.MODEL
+
+        val isPixel = manufacturer.equals("Google", ignoreCase = true) &&
+            model.contains("Pixel", ignoreCase = true)
+
+        if (!isPixel) {
+            Log.i("HybridAi", "[$label] Skipping Nano for non-Pixel device: $manufacturer $model")
+        }
+
+        return isPixel
     }
 
     private fun getActiveModel(): AiTextModel {

--- a/app/src/main/java/com/rpeters/jellyfin/data/ai/HybridAiTextModel.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/data/ai/HybridAiTextModel.kt
@@ -7,10 +7,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-
 import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.onCompletion
-import kotlinx.coroutines.flow.onStart
 import java.util.concurrent.atomic.AtomicInteger
 
 /**
@@ -67,7 +64,7 @@ class HybridAiTextModel(
     }
 
     private fun updateActiveState() {
-        _isNanoActive.value = !circuitBroken && 
+        _isNanoActive.value = !circuitBroken &&
             shouldUseOnDeviceAi() &&
             nanoModel.downloadState.value == AiDownloadState.READY
     }
@@ -102,7 +99,7 @@ class HybridAiTextModel(
     override suspend fun generateText(prompt: String): String {
         val model = getActiveModel()
         val isNano = model is MlKitAiTextModel
-        
+
         return try {
             val result = model.generateText(prompt)
             if (isNano) failureCount.set(0) // Reset on success
@@ -111,13 +108,13 @@ class HybridAiTextModel(
             if (isNano) {
                 val currentFailures = failureCount.incrementAndGet()
                 Log.w("HybridAi", "[$label] Nano failed ($currentFailures/3), falling back to cloud", e)
-                
+
                 if (currentFailures >= 3) {
                     Log.e("HybridAi", "[$label] Circuit broken for Nano! Switching to Cloud for this session.")
                     circuitBroken = true
                     updateActiveState()
                 }
-                
+
                 // Immediate fallback to cloud for this request
                 cloudModel.generateText(prompt)
             } else {
@@ -130,7 +127,7 @@ class HybridAiTextModel(
     override fun generateTextStream(prompt: String): Flow<String> {
         val model = getActiveModel()
         val isNano = model is MlKitAiTextModel
-        
+
         return if (isNano) {
             model.generateTextStream(prompt).catch { e ->
                 Log.w("HybridAi", "[$label] Nano stream failed, falling back to cloud", e)


### PR DESCRIPTION
### Motivation
- On-device Gemini Nano is intermittently unreliable on many non-Pixel devices, causing flaky AI summaries and assistant screens. 
- The goal is to prefer the cloud fallback on unsupported devices to provide consistent AI behavior and avoid repeated flaky retry loops.

### Description
- Added device gating with a centralized `shouldUseOnDeviceAi()` that combines `remoteConfig.getBoolean("enable_on_device_ai")` and a new `isOnDeviceAiDeviceSupported()` check. 
- Implemented `isOnDeviceAiDeviceSupported()` to restrict on-device Nano usage to Google Pixel devices by inspecting `Build.MANUFACTURER` and `Build.MODEL`, and added `import android.os.Build`.
- Applied the new gate to `initialize()`, `retryDownload()`, and `updateActiveState()` in `HybridAiTextModel` so initialization, retries, and active-state determination skip Nano on unsupported devices. 
- Improved logging to report both the remote-config flag and whether the device is supported, and short-circuited retry attempts on unsupported/disabled devices to avoid unnecessary download loops.

### Testing
- Attempted to compile Kotlin with `./gradlew :app:compileDebugKotlin`, which failed in this environment due to inability to resolve the Android Gradle plugin (`com.android.application:9.1.1`) from configured repositories. 
- No other automated tests were executed in this environment; the code changes were committed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6670b9bf88327ae51f45df13bbcc2)