### PR TITLE
Refactor auth refresh into concurrency-safe JellyfinAuthRefreshManager

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -43,6 +43,35 @@ jobs:
       - name: Ensure Gradle wrapper executable
         run: chmod +x gradlew
 
+      - name: Create placeholder google-services.json for CI
+        shell: bash
+        run: |
+          cat > app/google-services.json <<'JSON'
+          {
+            "project_info": {
+              "project_number": "1234567890",
+              "project_id": "cinefin-ci",
+              "storage_bucket": "cinefin-ci.appspot.com"
+            },
+            "client": [
+              {
+                "client_info": {
+                  "mobilesdk_app_id": "1:1234567890:android:abcdef123456",
+                  "android_client_info": {
+                    "package_name": "com.rpeters.jellyfin"
+                  }
+                },
+                "api_key": [
+                  {
+                    "current_key": "ci-placeholder-key"
+                  }
+                ]
+              }
+            ],
+            "configuration_version": "1"
+          }
+          JSON
+
       - name: Build debug APK
         run: ./gradlew --no-daemon --stacktrace :app:assembleDebug
 

--- a/app/src/main/java/com/rpeters/jellyfin/data/repository/IJellyfinAuthRefreshManager.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/data/repository/IJellyfinAuthRefreshManager.kt
@@ -1,0 +1,7 @@
+package com.rpeters.jellyfin.data.repository
+
+interface IJellyfinAuthRefreshManager {
+    fun currentAccessToken(): String?
+    fun scheduleProactiveRefreshIfNeeded()
+    fun refreshAfterUnauthorized(attempt: Int): String?
+}

--- a/app/src/main/java/com/rpeters/jellyfin/data/repository/JellyfinAuthRefreshManager.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/data/repository/JellyfinAuthRefreshManager.kt
@@ -4,6 +4,7 @@ import com.rpeters.jellyfin.di.ApplicationScope
 import com.rpeters.jellyfin.utils.SecureLogger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -43,12 +44,24 @@ class JellyfinAuthRefreshManager @Inject constructor(
     override fun refreshAfterUnauthorized(attempt: Int): String? {
         val trigger = "$REFRESH_TRIGGER_401-$attempt"
         val result = runBlocking {
-            withTimeoutOrNull(REFRESH_TIMEOUT_MS) {
-                runSingleFlightRefresh(trigger = trigger)
+            try {
+                withTimeoutOrNull(REFRESH_TIMEOUT_MS) {
+                    runSingleFlightRefresh(trigger = trigger)
+                } ?: run {
+                    clearInFlightRefresh()
+                    logTelemetry("failure", trigger, attempt, "timeout")
+                    RefreshResult.Failure("timeout")
+                }
+            } catch (error: Throwable) {
+                if (error is TimeoutCancellationException) {
+                    clearInFlightRefresh()
+                    logTelemetry("failure", trigger, attempt, "timeout_exception")
+                    return@runBlocking RefreshResult.Failure("timeout_exception")
+                }
+                clearInFlightRefresh()
+                SecureLogger.w(TAG, "Auth refresh exception for trigger=$trigger", error)
+                RefreshResult.Failure("exception")
             }
-        } ?: run {
-            logTelemetry("failure", trigger, attempt, "timeout")
-            RefreshResult.Failure("timeout")
         }
 
         return when (result) {
@@ -68,12 +81,16 @@ class JellyfinAuthRefreshManager @Inject constructor(
             }
             inFlightRefresh = created
             created.invokeOnCompletion {
-                applicationScope.launch {
-                    singleFlightMutex.withLock {
+                if (singleFlightMutex.tryLock()) {
+                    try {
                         if (inFlightRefresh === created) {
                             inFlightRefresh = null
                         }
+                    } finally {
+                        singleFlightMutex.unlock()
                     }
+                } else {
+                    applicationScope.launch { clearInFlightRefresh(expected = created, cancel = false) }
                 }
             }
             created
@@ -106,6 +123,19 @@ class JellyfinAuthRefreshManager @Inject constructor(
 
         SecureLogger.w(TAG, "Auth refresh exhausted retries for trigger=$trigger durationMs=$elapsed")
         return RefreshResult.Failure("retry_exhausted")
+    }
+
+    private suspend fun clearInFlightRefresh(expected: Deferred<RefreshResult>? = null, cancel: Boolean = true) {
+        singleFlightMutex.withLock {
+            val current = inFlightRefresh ?: return
+            if (expected != null && current !== expected) {
+                return
+            }
+            if (cancel) {
+                current.cancel()
+            }
+            inFlightRefresh = null
+        }
     }
 
     private fun logTelemetry(

--- a/app/src/main/java/com/rpeters/jellyfin/data/repository/JellyfinAuthRefreshManager.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/data/repository/JellyfinAuthRefreshManager.kt
@@ -1,0 +1,133 @@
+package com.rpeters.jellyfin.data.repository
+
+import android.util.Log
+import com.rpeters.jellyfin.di.ApplicationScope
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeoutOrNull
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.system.measureTimeMillis
+
+@Singleton
+class JellyfinAuthRefreshManager @Inject constructor(
+    private val authRepository: IJellyfinAuthRepository,
+    @ApplicationScope private val applicationScope: CoroutineScope,
+) : IJellyfinAuthRefreshManager {
+
+    private val singleFlightMutex = Mutex()
+    @Volatile
+    private var inFlightRefresh: Deferred<RefreshResult>? = null
+
+    override fun currentAccessToken(): String? {
+        return authRepository.getCurrentServer()?.accessToken
+    }
+
+    override fun scheduleProactiveRefreshIfNeeded() {
+        if (!authRepository.isUserAuthenticated() || !authRepository.shouldRefreshToken()) {
+            return
+        }
+
+        applicationScope.launch {
+            runSingleFlightRefresh(trigger = REFRESH_TRIGGER_PROACTIVE)
+        }
+    }
+
+    override fun refreshAfterUnauthorized(attempt: Int): String? {
+        val trigger = "$REFRESH_TRIGGER_401-$attempt"
+        val result = runBlocking {
+            withTimeoutOrNull(REFRESH_TIMEOUT_MS) {
+                runSingleFlightRefresh(trigger = trigger)
+            }
+        } ?: run {
+            logTelemetry("failure", trigger, attempt, "timeout")
+            RefreshResult.Failure("timeout")
+        }
+
+        return when (result) {
+            is RefreshResult.Success -> result.token
+            is RefreshResult.Failure -> {
+                logTelemetry("failure", trigger, attempt, result.reason)
+                null
+            }
+        }
+    }
+
+    private suspend fun runSingleFlightRefresh(trigger: String): RefreshResult {
+        val deferred = singleFlightMutex.withLock {
+            inFlightRefresh?.let { return@withLock it }
+            val created = applicationScope.async {
+                executeRefresh(trigger)
+            }
+            inFlightRefresh = created
+            created.invokeOnCompletion {
+                applicationScope.launch {
+                    singleFlightMutex.withLock {
+                        if (inFlightRefresh === created) {
+                            inFlightRefresh = null
+                        }
+                    }
+                }
+            }
+            created
+        }
+
+        return deferred.await()
+    }
+
+    private suspend fun executeRefresh(trigger: String): RefreshResult {
+        val elapsed = measureTimeMillis {
+            repeat(MAX_REFRESH_RETRIES) { retryIndex ->
+                val delayMs = RETRY_BACKOFF_MS[retryIndex]
+                if (delayMs > 0L) {
+                    delay(delayMs)
+                }
+
+                val refreshed = authRepository.forceReAuthenticate()
+                if (refreshed) {
+                    val token = authRepository.getCurrentServer()?.accessToken
+                    if (!token.isNullOrBlank()) {
+                        logTelemetry("success", trigger, retryIndex + 1, null)
+                        return RefreshResult.Success(token)
+                    }
+                    logTelemetry("failure", trigger, retryIndex + 1, "missing_token")
+                } else {
+                    logTelemetry("failure", trigger, retryIndex + 1, "reauth_failed")
+                }
+            }
+        }
+
+        Log.w(TAG, "Auth refresh exhausted retries for trigger=$trigger durationMs=$elapsed")
+        return RefreshResult.Failure("retry_exhausted")
+    }
+
+    private fun logTelemetry(
+        outcome: String,
+        trigger: String,
+        attempt: Int,
+        reason: String?,
+    ) {
+        val reasonPart = reason?.let { " reason=$it" } ?: ""
+        Log.i(TAG, "AuthRefreshEvent outcome=$outcome trigger=$trigger attempt=$attempt$reasonPart")
+    }
+
+    private sealed class RefreshResult {
+        data class Success(val token: String) : RefreshResult()
+        data class Failure(val reason: String) : RefreshResult()
+    }
+
+    companion object {
+        private const val TAG = "JellyfinAuthRefreshManager"
+        private const val REFRESH_TRIGGER_PROACTIVE = "proactive"
+        private const val REFRESH_TRIGGER_401 = "http_401"
+        private const val REFRESH_TIMEOUT_MS = 10_000L
+        private const val MAX_REFRESH_RETRIES = 3
+        private val RETRY_BACKOFF_MS = longArrayOf(0L, 100L, 500L)
+    }
+}

--- a/app/src/main/java/com/rpeters/jellyfin/data/repository/JellyfinAuthRefreshManager.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/data/repository/JellyfinAuthRefreshManager.kt
@@ -22,6 +22,7 @@ class JellyfinAuthRefreshManager @Inject constructor(
 ) : IJellyfinAuthRefreshManager {
 
     private val singleFlightMutex = Mutex()
+
     @Volatile
     private var inFlightRefresh: Deferred<RefreshResult>? = null
 

--- a/app/src/main/java/com/rpeters/jellyfin/data/repository/JellyfinAuthRefreshManager.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/data/repository/JellyfinAuthRefreshManager.kt
@@ -1,7 +1,7 @@
 package com.rpeters.jellyfin.data.repository
 
-import android.util.Log
 import com.rpeters.jellyfin.di.ApplicationScope
+import com.rpeters.jellyfin.utils.SecureLogger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
@@ -84,8 +84,8 @@ class JellyfinAuthRefreshManager @Inject constructor(
 
     private suspend fun executeRefresh(trigger: String): RefreshResult {
         val elapsed = measureTimeMillis {
-            repeat(MAX_REFRESH_RETRIES) { retryIndex ->
-                val delayMs = RETRY_BACKOFF_MS[retryIndex]
+            repeat(RETRY_BACKOFF_MS.size) { retryIndex ->
+                val delayMs = RETRY_BACKOFF_MS.getOrElse(retryIndex) { RETRY_BACKOFF_MS.last() }
                 if (delayMs > 0L) {
                     delay(delayMs)
                 }
@@ -104,7 +104,7 @@ class JellyfinAuthRefreshManager @Inject constructor(
             }
         }
 
-        Log.w(TAG, "Auth refresh exhausted retries for trigger=$trigger durationMs=$elapsed")
+        SecureLogger.w(TAG, "Auth refresh exhausted retries for trigger=$trigger durationMs=$elapsed")
         return RefreshResult.Failure("retry_exhausted")
     }
 
@@ -115,7 +115,7 @@ class JellyfinAuthRefreshManager @Inject constructor(
         reason: String?,
     ) {
         val reasonPart = reason?.let { " reason=$it" } ?: ""
-        Log.i(TAG, "AuthRefreshEvent outcome=$outcome trigger=$trigger attempt=$attempt$reasonPart")
+        SecureLogger.i(TAG, "AuthRefreshEvent outcome=$outcome trigger=$trigger attempt=$attempt$reasonPart")
     }
 
     private sealed class RefreshResult {
@@ -128,7 +128,6 @@ class JellyfinAuthRefreshManager @Inject constructor(
         private const val REFRESH_TRIGGER_PROACTIVE = "proactive"
         private const val REFRESH_TRIGGER_401 = "http_401"
         private const val REFRESH_TIMEOUT_MS = 10_000L
-        private const val MAX_REFRESH_RETRIES = 3
         private val RETRY_BACKOFF_MS = longArrayOf(0L, 100L, 500L)
     }
 }

--- a/app/src/main/java/com/rpeters/jellyfin/di/NetworkModule.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/di/NetworkModule.kt
@@ -8,8 +8,10 @@ import com.rpeters.jellyfin.data.cache.JellyfinCache
 import com.rpeters.jellyfin.data.playback.EnhancedPlaybackManager
 import com.rpeters.jellyfin.data.preferences.PlaybackPreferencesRepository
 import com.rpeters.jellyfin.data.repository.ICastPlaybackRepository
+import com.rpeters.jellyfin.data.repository.IJellyfinAuthRefreshManager
 import com.rpeters.jellyfin.data.repository.IJellyfinAuthRepository
 import com.rpeters.jellyfin.data.repository.IJellyfinRepository
+import com.rpeters.jellyfin.data.repository.JellyfinAuthRefreshManager
 import com.rpeters.jellyfin.data.repository.JellyfinAuthRepository
 import com.rpeters.jellyfin.data.repository.JellyfinRepository
 import com.rpeters.jellyfin.data.repository.JellyfinStreamRepository
@@ -113,10 +115,10 @@ object NetworkModule {
     @Provides
     @Singleton
     fun provideJellyfinAuthInterceptor(
-        authRepositoryProvider: Provider<IJellyfinAuthRepository>,
+        authRefreshManager: IJellyfinAuthRefreshManager,
         deviceIdentityProvider: DeviceIdentityProvider,
     ): JellyfinAuthInterceptor {
-        return JellyfinAuthInterceptor(authRepositoryProvider, deviceIdentityProvider)
+        return JellyfinAuthInterceptor(authRefreshManager, deviceIdentityProvider)
     }
 
     @Provides
@@ -217,6 +219,12 @@ object NetworkModule {
     fun provideIJellyfinAuthRepository(
         authRepository: JellyfinAuthRepository,
     ): IJellyfinAuthRepository = authRepository
+
+    @Provides
+    @Singleton
+    fun provideIJellyfinAuthRefreshManager(
+        refreshManager: JellyfinAuthRefreshManager,
+    ): IJellyfinAuthRefreshManager = refreshManager
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/rpeters/jellyfin/network/JellyfinAuthInterceptor.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/network/JellyfinAuthInterceptor.kt
@@ -149,6 +149,5 @@ class JellyfinAuthInterceptor @Inject constructor(
         private const val HEADER_USER_AGENT = "User-Agent"
         private const val MAX_AUTH_RETRIES = 3
         private val AUTH_PATHS = listOf("/Users/Authenticate", "/Sessions")
-
     }
 }

--- a/app/src/main/java/com/rpeters/jellyfin/network/JellyfinAuthInterceptor.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/network/JellyfinAuthInterceptor.kt
@@ -1,50 +1,38 @@
 package com.rpeters.jellyfin.network
 
-import com.rpeters.jellyfin.data.repository.IJellyfinAuthRepository
-import com.rpeters.jellyfin.data.repository.JellyfinAuthRepository
+import com.rpeters.jellyfin.data.repository.IJellyfinAuthRefreshManager
 import com.rpeters.jellyfin.utils.SecureLogger
-import kotlinx.coroutines.runBlocking
 import okhttp3.Authenticator
 import okhttp3.Interceptor
 import okhttp3.Request
 import okhttp3.Response
 import okhttp3.Route
 import javax.inject.Inject
-import javax.inject.Provider
 import javax.inject.Singleton
 
 /**
  * Authentication interceptor for Jellyfin API requests.
  *
- * **Optimization Strategy**:
- * - Proactively refreshes tokens 5 minutes before expiration to minimize blocking
- * - Uses authMutex in JellyfinAuthRepository to prevent concurrent refresh attempts
- * - Optimized backoff delays (0ms, 100ms, 500ms) to reduce total blocking time
- * - Double-check pattern in forceReAuthenticate() avoids redundant refreshes
- *
- * **Thread Safety**:
- * - Uses runBlocking (required by OkHttp's synchronous API)
- * - OkHttp runs interceptors on background threads, so blocking is acceptable
- * - Mutex protection in repository prevents stampeding herd problem
+ * Keeps request interception lightweight by reading the current token and
+ * delegating refresh orchestration to JellyfinAuthRefreshManager.
  */
 @Singleton
 class JellyfinAuthInterceptor @Inject constructor(
-    private val authRepositoryProvider: Provider<IJellyfinAuthRepository>,
+    private val authRefreshManager: IJellyfinAuthRefreshManager,
     private val deviceIdentityProvider: DeviceIdentityProvider,
 ) : Interceptor, Authenticator {
 
     override fun intercept(chain: Interceptor.Chain): Response {
         val request = chain.request()
         val shouldAttachToken = !isAuthenticationRequest(request)
-        val repository = authRepositoryProvider.get()
 
         val token = if (shouldAttachToken) {
-            ensureFreshToken(repository)
-            val server = repository.getCurrentServer()
-            if (server?.accessToken == null) {
-                SecureLogger.w(TAG, "No access token available after token refresh attempt")
+            authRefreshManager.scheduleProactiveRefreshIfNeeded()
+            val currentToken = authRefreshManager.currentAccessToken()
+            if (currentToken == null) {
+                SecureLogger.w(TAG, "No access token available while building request")
             }
-            server?.accessToken
+            currentToken
         } else {
             null
         }
@@ -58,50 +46,15 @@ class JellyfinAuthInterceptor @Inject constructor(
             return null
         }
 
-        val repository = authRepositoryProvider.get()
         val attempt = responseCount(response)
-        backoff(attempt)
+        val token = authRefreshManager.refreshAfterUnauthorized(attempt)
 
-        // Note: runBlocking is necessary here as OkHttp's Authenticator is a synchronous API
-        // OkHttp already runs this on a background thread, so we don't need to switch dispatchers
-        val refreshed = runBlocking {
-            repository.forceReAuthenticate()
-        }
-
-        if (!refreshed) {
+        if (token.isNullOrBlank()) {
             SecureLogger.w(TAG, "Failed to refresh token after 401 (attempt $attempt)")
             return null
         }
 
-        val token = repository.getCurrentServer()?.accessToken
-        if (token == null) {
-            SecureLogger.w(TAG, "No token available after successful re-authentication (attempt $attempt)")
-            return null
-        }
-
         return buildRequestWithHeaders(response.request, token)
-    }
-
-    private fun ensureFreshToken(repository: IJellyfinAuthRepository) {
-        if (!repository.isUserAuthenticated()) {
-            return
-        }
-
-        // Proactively refresh if token is approaching expiration (not just expired)
-        // This reduces the likelihood of blocking on expired tokens
-        if (!repository.shouldRefreshToken()) {
-            return
-        }
-
-        // Note: runBlocking is necessary here as Interceptor.intercept() is a synchronous API
-        // OkHttp already runs this on a background thread, so we don't need to switch dispatchers
-        // The authMutex in forceReAuthenticate() prevents concurrent refresh attempts
-        runBlocking {
-            val refreshed = repository.forceReAuthenticate()
-            if (!refreshed) {
-                SecureLogger.w(TAG, "Token refresh failed during request preparation")
-            }
-        }
     }
 
     private fun buildRequestWithHeaders(
@@ -181,21 +134,6 @@ class JellyfinAuthInterceptor @Inject constructor(
         return count
     }
 
-    private fun backoff(attempt: Int) {
-        val delayMillis = when {
-            attempt <= RETRY_BACKOFF_MS.size -> RETRY_BACKOFF_MS[attempt - 1]
-            else -> RETRY_BACKOFF_MS.last()
-        }
-
-        if (delayMillis <= 0) {
-            return
-        }
-
-        // Use Thread.sleep for synchronous backoff (required by OkHttp's synchronous API)
-        // Optimized delays to reduce blocking: first retry immediate, subsequent retries use minimal backoff
-        Thread.sleep(delayMillis)
-    }
-
     private fun isAuthenticationRequest(request: Request): Boolean {
         val url = request.url.toString()
         return AUTH_PATHS.any { url.contains(it, ignoreCase = true) }
@@ -212,8 +150,5 @@ class JellyfinAuthInterceptor @Inject constructor(
         private const val MAX_AUTH_RETRIES = 3
         private val AUTH_PATHS = listOf("/Users/Authenticate", "/Sessions")
 
-        // Optimized backoff delays: 0ms (immediate), 100ms, 500ms
-        // Reduced from 0ms, 250ms, 1000ms to minimize thread blocking
-        private val RETRY_BACKOFF_MS = longArrayOf(0L, 100L, 500L)
     }
 }

--- a/app/src/test/java/com/rpeters/jellyfin/data/repository/JellyfinAuthRefreshManagerTest.kt
+++ b/app/src/test/java/com/rpeters/jellyfin/data/repository/JellyfinAuthRefreshManagerTest.kt
@@ -1,0 +1,81 @@
+package com.rpeters.jellyfin.data.repository
+
+import android.util.Log
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.supervisorScope
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class JellyfinAuthRefreshManagerTest {
+    private lateinit var authRepository: IJellyfinAuthRepository
+    private lateinit var refreshManager: JellyfinAuthRefreshManager
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this, relaxUnitFun = true)
+        authRepository = mockk(relaxed = true)
+
+        mockkStatic(Log::class)
+        every { Log.i(any(), any()) } returns 0
+        every { Log.w(any(), any()) } returns 0
+
+        refreshManager = JellyfinAuthRefreshManager(
+            authRepository = authRepository,
+            applicationScope = CoroutineScope(Dispatchers.Default),
+        )
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `simultaneous unauthorized refresh requests execute a single refresh`() = runTest {
+        coEvery { authRepository.forceReAuthenticate() } coAnswers {
+            delay(100)
+            true
+        }
+        every { authRepository.getCurrentServer() } returns mockk {
+            every { accessToken } returns "shared-token"
+        }
+
+        val tokens = supervisorScope {
+            (1..10).map {
+                async(Dispatchers.Default) {
+                    refreshManager.refreshAfterUnauthorized(attempt = 1)
+                }
+            }.awaitAll()
+        }
+
+        assertEquals(List(10) { "shared-token" }, tokens)
+        coVerify(exactly = 1) { authRepository.forceReAuthenticate() }
+    }
+
+    @Test
+    fun `returns null when all refresh attempts fail`() = runTest {
+        coEvery { authRepository.forceReAuthenticate() } returns false
+
+        val token = refreshManager.refreshAfterUnauthorized(attempt = 1)
+
+        assertNull(token)
+        coVerify(exactly = 3) { authRepository.forceReAuthenticate() }
+    }
+}

--- a/app/src/test/java/com/rpeters/jellyfin/data/repository/JellyfinAuthRefreshManagerTest.kt
+++ b/app/src/test/java/com/rpeters/jellyfin/data/repository/JellyfinAuthRefreshManagerTest.kt
@@ -34,7 +34,7 @@ class JellyfinAuthRefreshManagerTest {
 
         mockkStatic(Log::class)
         every { Log.i(any(), any()) } returns 0
-        every { Log.w(any(), any()) } returns 0
+        every { Log.w(any(), any<String>()) } returns 0
 
         refreshManager = JellyfinAuthRefreshManager(
             authRepository = authRepository,


### PR DESCRIPTION
### Motivation
- Prevent blocking interceptor threads by moving token refresh orchestration out of the OkHttp interceptor into a concurrency-safe manager.  
- Ensure only one refresh runs for concurrent 401 responses (single-flight), use coroutine-friendly backoff and timeouts, and surface fast-fail behavior in the interceptor.  

### Description
- Introduced `IJellyfinAuthRefreshManager` and `JellyfinAuthRefreshManager` to centralize refresh orchestration, add single-flight coordination, coroutine `delay` backoff, retry cap, and a timeout.  
- Simplified `JellyfinAuthInterceptor` to a fast path that atomically reads the current token, schedules proactive refresh asynchronously, attaches headers, and uses the refresh manager for 401 handling without blocking sleeps.  
- Updated Hilt wiring in `NetworkModule` to provide `JellyfinAuthRefreshManager` and inject `IJellyfinAuthRefreshManager` into the interceptor.  
- Added `JellyfinAuthRefreshManagerTest` with coverage for simultaneous 401 handling (ensures a single refresh runs) and retry exhaustion behavior.  

### Testing
- Added unit tests `JellyfinAuthRefreshManagerTest` that assert a single refresh occurs under concurrent unauthorized requests and that failed refreshes exhaust retries and return `null`.  
- An attempt to run `:app:testDebugUnitTest --tests com.rpeters.jellyfin.data.repository.JellyfinAuthRefreshManagerTest --tests com.rpeters.jellyfin.data.repository.JellyfinAuthRepositoryTest` failed in this environment because the Android Gradle plugin `com.android.application:9.2.0` could not be resolved from configured repositories, so tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e959239b40832789c35087517a8ec1)