### PR TITLE
docs: align status/roadmap/known-issues/improvement-plan and add canonical truth table

### DIFF
--- a/docs/development/CONTRIBUTING.md
+++ b/docs/development/CONTRIBUTING.md
@@ -22,6 +22,15 @@ We use GitHub to host code, track issues and feature requests, as well as accept
 6. **Update documentation** as needed
 7. **Create a pull request**
 
+### **Documentation Maintenance Checklist (Required for shipped features)**
+When a PR ships a user-visible feature or closes a roadmap item, update docs in the same PR:
+
+- [ ] Update `docs/plans/CURRENT_STATUS.md` feature truth table and any affected status rows.
+- [ ] Update `docs/plans/ROADMAP.md` by checking off, relabeling, or removing completed scope.
+- [ ] Update `docs/features/KNOWN_ISSUES.md` so each open issue links to exactly one canonical implementation plan.
+- [ ] Update `docs/plans/IMPROVEMENT_PLAN.md` if technical debt scope changed.
+- [ ] Set the same `Last verified on YYYY-MM-DD` date across all status/planning docs touched.
+
 ### **Branch Naming**
 - `feature/description` - for new features
 - `bugfix/description` - for bug fixes

--- a/docs/features/KNOWN_ISSUES.md
+++ b/docs/features/KNOWN_ISSUES.md
@@ -1,8 +1,8 @@
 # Jellyfin Android - Known Issues
 
-**Last Updated**: January 30, 2026
+**Last verified on**: 2026-04-22
 
-This document tracks user-facing bugs, workarounds, and fix status. For technical debt and code quality improvements, see [docs/IMPROVEMENT_PLAN.md](docs/IMPROVEMENT_PLAN.md). For feature status, see [CURRENT_STATUS.md](CURRENT_STATUS.md). For planned features, see [ROADMAP.md](ROADMAP.md).
+This document tracks user-facing bugs, workarounds, and fix status. For technical debt and code quality improvements, see [docs/plans/IMPROVEMENT_PLAN.md](../plans/IMPROVEMENT_PLAN.md). For feature status, see [CURRENT_STATUS.md](../plans/CURRENT_STATUS.md). For planned features, see [ROADMAP.md](../plans/ROADMAP.md).
 
 ---
 
@@ -52,7 +52,8 @@ This document tracks user-facing bugs, workarounds, and fix status. For technica
 - None for users - token refresh is automatic
 - If experiencing network timeouts, restart app to force new session
 
-**Fix Status**: 🔜 Planned - [IMPROVEMENT_PLAN Priority 8](docs/IMPROVEMENT_PLAN.md)
+**Fix Status**: 🔜 Planned
+**Canonical Plan**: [IMPROVEMENT_PLAN §Phase C](../plans/IMPROVEMENT_PLAN.md#phase-c-reliability--error-handling-high)
 **Target**: Phase 3 - Code Quality
 
 **Code Location**:
@@ -86,41 +87,43 @@ private fun backoff(attempt: Int) {
 - Use screen timeout settings to keep app active longer
 - Consider using Jellyfin web player or other clients for music
 
-**Fix Status**: 🔜 In Progress - [ROADMAP §1.1](ROADMAP.md#11-music-background-playback)
+**Fix Status**: 🔜 In Progress
+**Canonical Plan**: [ROADMAP §1.1](../plans/ROADMAP.md#11-music-background-playback)
 **Target**: Phase 1 - Complete Core Features
 **Effort**: 5-7 days
 
 ---
 
-### #7: Offline Downloads Non-Functional
+### #7: Offline Downloads Reliability Edge Cases
 
-**Impact**: Cannot download media for offline viewing
-**Affected Users**: All users attempting offline downloads
+**Impact**: Core offline downloads work, but long-running/background edge cases can still fail
+**Affected Users**: Subset of users on constrained networks or aggressive OEM background policies
 **Files**:
 - `app/src/main/java/com/rpeters/jellyfin/data/offline/OfflineDownloadManager.kt`
 - `app/src/main/java/com/rpeters/jellyfin/ui/downloads/DownloadsScreen.kt`
 
 **Details**:
-- Downloads UI screens exist but core download logic is incomplete
-- No WorkManager integration for background downloads
-- No download progress tracking
-- No offline playback detection in `VideoPlayerViewModel`
-- No storage management UI
-- No WiFi-only download option
+- Offline downloads are implemented and generally functional
+- Remaining risk is reliability under prolonged background constraints and intermittent connectivity
+- Validation focus is WorkManager constraints, retry behavior, and resume handling after process death
 
 **Workaround**:
-- Use online streaming only
-- Ensure stable network connection for uninterrupted playback
-- Pre-buffer content by starting playback before watching
+- Keep app unrestricted by battery optimization when downloading large libraries
+- Prefer stable Wi-Fi for large jobs
 
-**Fix Status**: 🔜 In Progress - [ROADMAP §1.2](ROADMAP.md#12-offline-downloads)
-**Target**: Phase 1 - Complete Core Features
-**Effort**: 5-7 days
+**Fix Status**: 🔜 Planned
+**Canonical Plan**: [IMPROVEMENT_PLAN §Phase C](../plans/IMPROVEMENT_PLAN.md#phase-c-reliability--error-handling-high)
+**Target**: Reliability hardening
+**Effort**: 2-4 days of validation + fixes
+
+**Verification**:
+- Feature marked **Complete** in [CURRENT_STATUS truth table](../plans/CURRENT_STATUS.md#feature-truth-table-canonical)
+- Roadmap item is explicitly marked complete (section 1.2)
 
 **Recently Fixed** (January 2026):
 - ✅ Download hanging bug (infinite DataStore Flow collection) - Fixed
 - ✅ Download ID mismatch (placeholder UUID vs real ID) - Fixed
-- See [IMPROVEMENT_PLAN](docs/IMPROVEMENT_PLAN.md) for details
+- See [IMPROVEMENT_PLAN](../plans/IMPROVEMENT_PLAN.md) for details
 
 ---
 
@@ -143,9 +146,10 @@ private fun backoff(attempt: Int) {
 
 **Workaround**:
 - None for users
-- Developers: Refactor screens into smaller composables (see [ROADMAP §3.1](ROADMAP.md#31-refactor-large-files))
+- Developers: Refactor screens into smaller composables
 
-**Fix Status**: 🔜 Planned - [ROADMAP §3.1](ROADMAP.md#31-refactor-large-files)
+**Fix Status**: 🔜 Planned
+**Canonical Plan**: [IMPROVEMENT_PLAN §Phase F](../plans/IMPROVEMENT_PLAN.md#phase-f-code-quality--technical-debt-carried-forward)
 **Target**: Phase 3 - Code Quality
 **Effort**: 3-5 days
 
@@ -166,9 +170,10 @@ private fun backoff(attempt: Int) {
 
 **Workaround**:
 - Ignore warnings - they are non-critical
-- Developers: See [ROADMAP §3.2](ROADMAP.md#32-fix-build-warnings)
+- Developers: See canonical plan below
 
-**Fix Status**: 🔜 Planned - [ROADMAP §3.2](ROADMAP.md#32-fix-build-warnings)
+**Fix Status**: 🔜 Planned
+**Canonical Plan**: [IMPROVEMENT_PLAN §Phase F](../plans/IMPROVEMENT_PLAN.md#phase-f-code-quality--technical-debt-carried-forward)
 **Target**: Phase 3 - Code Quality
 **Effort**: 2-3 hours
 
@@ -196,7 +201,8 @@ private fun backoff(attempt: Int) {
 - Restart app if stuck in navigation dead-end
 - Report specific navigation issues on GitHub
 
-**Fix Status**: 🔜 Planned - [ROADMAP §2.1](ROADMAP.md#21-d-pad-navigation-audit)
+**Fix Status**: 🔜 Planned
+**Canonical Plan**: [ROADMAP §2.1](../plans/ROADMAP.md#21-d-pad-navigation-audit)
 **Target**: Phase 2 - Android TV Polish
 **Effort**: 3-5 days
 
@@ -311,7 +317,7 @@ For a summary of active issues and overall project status, please refer to the *
 
 ### Before Reporting
 1. **Check this document** to see if the issue is already known
-2. **Check [ROADMAP.md](ROADMAP.md)** to see if the feature is in progress
+2. **Check [ROADMAP.md](../plans/ROADMAP.md)** to see if the feature is in progress
 3. **Update to latest version** to ensure issue still exists
 4. **Check GitHub issues** for existing reports
 
@@ -372,10 +378,10 @@ We welcome contributions to fix these issues! See [CONTRIBUTING.md](CONTRIBUTING
 
 ## Related Documentation
 
-- **[CURRENT_STATUS.md](CURRENT_STATUS.md)** - What works now, feature status matrix
-- **[ROADMAP.md](ROADMAP.md)** - Future features and development roadmap
+- **[CURRENT_STATUS.md](../plans/CURRENT_STATUS.md)** - What works now, feature status matrix
+- **[ROADMAP.md](../plans/ROADMAP.md)** - Future features and development roadmap
 - **[UPGRADE_PATH.md](UPGRADE_PATH.md)** - Dependency upgrade strategy
-- **[docs/IMPROVEMENT_PLAN.md](docs/IMPROVEMENT_PLAN.md)** - Technical debt and code quality focus
+- **[docs/plans/IMPROVEMENT_PLAN.md](../plans/IMPROVEMENT_PLAN.md)** - Technical debt and code quality focus
 - **[CONTRIBUTING.md](CONTRIBUTING.md)** - How to contribute fixes
 - **[CLAUDE.md](CLAUDE.md)** - Development guidelines and architecture
 
@@ -383,7 +389,7 @@ We welcome contributions to fix these issues! See [CONTRIBUTING.md](CONTRIBUTING
 
 ## Notes
 
-- **User vs Developer Issues**: This document focuses on user-facing bugs. For technical debt and code quality issues, see [docs/IMPROVEMENT_PLAN.md](docs/IMPROVEMENT_PLAN.md).
+- **User vs Developer Issues**: This document focuses on user-facing bugs. For technical debt and code quality issues, see [docs/plans/IMPROVEMENT_PLAN.md](../plans/IMPROVEMENT_PLAN.md).
 - **Priority Definitions**:
   - 🔴 **Critical**: App crashes, data loss, security issues
   - 🟠 **High**: Major functionality broken, affects all users, potential data corruption

--- a/docs/plans/CURRENT_STATUS.md
+++ b/docs/plans/CURRENT_STATUS.md
@@ -1,12 +1,22 @@
 # Jellyfin Android - Current Status
 
-**Last Updated**: March 30, 2026
+**Last verified on**: 2026-04-22
 
 > **Quick Links**: [Feature Status](CURRENT_STATUS.md) | [Known Issues](../features/KNOWN_ISSUES.md) | [Roadmap](ROADMAP.md) | [Upgrade Path](UPGRADE_PATH.md)
 
 This document provides a comprehensive snapshot of what works RIGHT NOW in the Jellyfin Android client. For planned features and improvements, see [ROADMAP.md](ROADMAP.md). For known bugs and workarounds, see [KNOWN_ISSUES.md](../features/KNOWN_ISSUES.md). For dependency upgrade strategy, see [UPGRADE_PATH.md](UPGRADE_PATH.md).
 
 ---
+
+## Feature Truth Table (Canonical)
+
+| Status | Meaning | Current Features |
+|---|---|---|
+| **Complete** | Implemented and validated in current app behavior | Authentication, Secure Storage, Certificate Pinning, Video Playback, Adaptive Bitrate, Transcoding Diagnostics, AI Assistant, AI Summaries, Library Browsing, Search, Favorites, Resume Playback, Picture-in-Picture, Chromecast, Auto-Play Next Episode, **Offline Downloads**, Firebase Integration, Material 3 UI, Adaptive Navigation, Recently Added Carousel |
+| **Partial** | User-visible functionality exists but key capabilities are still missing | Music Playback, Android TV |
+| **Not started** | Not yet implemented (backlog only) | Live TV & DVR, Sync Play, Multi-Profile Support, Home Screen Widgets |
+
+This table is the source of truth used by [ROADMAP.md](ROADMAP.md), [KNOWN_ISSUES.md](../features/KNOWN_ISSUES.md), and [IMPROVEMENT_PLAN.md](IMPROVEMENT_PLAN.md).
 
 ## Feature Status Matrix
 
@@ -166,14 +176,13 @@ This document provides a comprehensive snapshot of what works RIGHT NOW in the J
 
 ### Active Development
 - 🔄 Music background playback (in progress - [ROADMAP §1.1](ROADMAP.md))
-- 🔄 Offline downloads reliability polish (Wi-Fi-only WorkManager constraints and long-run validation)
 - 🔄 Android TV D-pad navigation testing (in progress - [ROADMAP §2.1](ROADMAP.md))
 
 ### Code Quality Focus
 - 🎯 Test coverage target: 70%+ for ViewModels and Repositories
 - 🎯 Refactoring large composables (ongoing - [ROADMAP §3.1](ROADMAP.md))
 - 🎯 Fixing build warnings (planned - [ROADMAP §3.2](ROADMAP.md))
-- 🎯 Auth refresh retry improvements (planned - [KNOWN_ISSUES #5](../features/KNOWN_ISSUES.md))
+- 🎯 Auth refresh retry improvements (planned - [IMPROVEMENT_PLAN §Phase C](IMPROVEMENT_PLAN.md#phase-c-reliability--error-handling-high))
 
 ---
 

--- a/docs/plans/IMPROVEMENT_PLAN.md
+++ b/docs/plans/IMPROVEMENT_PLAN.md
@@ -1,10 +1,12 @@
 # Jellyfin Android Improvement Plan
 
-**Last Updated**: February 4, 2026
+**Last verified on**: 2026-04-22
 **Scope**: Full codebase audit covering transcoding/playback, security, accessibility, UX, and code quality
 **Previous Version**: January 30, 2026 (see docs/archive/ for older plans)
 
-> **Note**: For user-facing bugs with workarounds, see [KNOWN_ISSUES.md](../KNOWN_ISSUES.md). For feature roadmap, see [ROADMAP.md](../ROADMAP.md). This document focuses on technical debt, architecture improvements, and code quality.
+> **Note**: For user-facing bugs with workarounds, see [KNOWN_ISSUES.md](../features/KNOWN_ISSUES.md). For feature roadmap, see [ROADMAP.md](ROADMAP.md). This document focuses on technical debt, architecture improvements, and code quality.
+
+> **Status alignment**: Transcoding/playback overhaul and offline downloads are treated as completed baseline work; only follow-up hardening remains open.
 
 ---
 
@@ -389,7 +391,7 @@ Based on user impact and technical debt:
 
 ## Related Documentation
 
-- [KNOWN_ISSUES.md](../KNOWN_ISSUES.md)
-- [ROADMAP.md](../ROADMAP.md)
+- [KNOWN_ISSUES.md](../features/KNOWN_ISSUES.md)
+- [ROADMAP.md](ROADMAP.md)
 - [TRANSCODING_FIX_SUMMARY.md](../TRANSCODING_FIX_SUMMARY.md)
 - [TESTING_GUIDE.md](TESTING_GUIDE.md) - ViewModel testing patterns and best practices

--- a/docs/plans/ROADMAP.md
+++ b/docs/plans/ROADMAP.md
@@ -1,8 +1,8 @@
 # Jellyfin Android - Roadmap
 
-**Last Updated**: February 4, 2026
+**Last verified on**: 2026-04-22
 
-> **Quick Links**: [Feature Status](CURRENT_STATUS.md) | [Known Issues](KNOWN_ISSUES.md) | [Upgrade Path](UPGRADE_PATH.md)
+> **Quick Links**: [Feature Status](CURRENT_STATUS.md) | [Known Issues](../features/KNOWN_ISSUES.md) | [Upgrade Path](UPGRADE_PATH.md)
 
 A clear, actionable improvement plan for the Jellyfin Android client.
 
@@ -28,18 +28,18 @@ Tasks:
 
 Files: `ui/player/audio/AudioService.kt`, `ui/components/MiniPlayer.kt`, `ui/screens/NowPlayingScreen.kt`
 
-### 1.2 Offline Downloads
-**Priority**: High | **Effort**: 5-7 days
+### 1.2 Offline Downloads — COMPLETE ✅
+**Status**: Verified complete (February 2026) per [CURRENT_STATUS truth table](CURRENT_STATUS.md#feature-truth-table-canonical)
 
-Tasks:
-- [ ] Complete `OfflineDownloadManager.kt` download logic
-- [ ] Add WorkManager for background downloads
-- [ ] Implement download progress tracking
-- [ ] Add offline playback detection in `VideoPlayerViewModel`
-- [ ] Add storage management UI
-- [ ] Support WiFi-only downloads
+Completed:
+- [x] `OfflineDownloadManager.kt` core download logic
+- [x] WorkManager background downloads
+- [x] Download progress tracking + notifications
+- [x] Offline playback routing in `VideoPlayerViewModel`
+- [x] Storage management UI + delete/cleanup
+- [x] Wi-Fi-only download option
 
-Files: `data/offline/OfflineDownloadManager.kt`, `ui/downloads/DownloadsScreen.kt`
+Follow-up reliability fixes are tracked in [IMPROVEMENT_PLAN §Phase C](IMPROVEMENT_PLAN.md#phase-c-reliability--error-handling-high).
 
 ### 1.3 Chromecast - COMPLETE
 **Status**: Verified and enhanced (January 2026)
@@ -70,9 +70,9 @@ Files: `ui/player/VideoPlayerActivity.kt`, `ui/player/PipActionReceiver.kt`
 
 ---
 
-## Phase 1.5: Transcoding & Playback System Overhaul
+## Phase 1.5: Transcoding & Playback System Overhaul — COMPLETED ✅
 
-> **Full Details**: [docs/IMPROVEMENT_PLAN.md - Phase A](docs/IMPROVEMENT_PLAN.md#phase-a-transcoding--playback-system-overhaul-critical)
+> **Full Details**: [IMPROVEMENT_PLAN.md - Phase A](IMPROVEMENT_PLAN.md#phase-a-transcoding--playback-system-overhaul-completed-)
 
 The transcoding system works for basic playback but has architectural gaps that cause unnecessary transcoding and degrade quality. This phase addresses the critical server communication and decision-making issues.
 
@@ -80,10 +80,10 @@ The transcoding system works for basic playback but has architectural gaps that 
 **Priority**: Critical | **Effort**: 5-7 days
 
 Tasks:
-- [ ] Implement Jellyfin DeviceProfile specification (send device capabilities to server)
-- [ ] Fix broken network quality assessment (currently hardcoded to HIGH)
-- [ ] Send AudioStreamIndex/SubtitleStreamIndex to server for multilingual content
-- [ ] Implement transcoding session lifecycle (heartbeat, cleanup)
+- [x] Implement Jellyfin DeviceProfile specification (send device capabilities to server)
+- [x] Fix broken network quality assessment (currently hardcoded to HIGH)
+- [x] Send AudioStreamIndex/SubtitleStreamIndex to server for multilingual content
+- [x] Implement transcoding session lifecycle (heartbeat, cleanup)
 
 Files: `data/DeviceCapabilities.kt`, `data/repository/JellyfinStreamRepository.kt`, `data/playback/EnhancedPlaybackManager.kt`
 
@@ -91,10 +91,10 @@ Files: `data/DeviceCapabilities.kt`, `data/repository/JellyfinStreamRepository.k
 **Priority**: High | **Effort**: 3-5 days
 
 Tasks:
-- [ ] Make bitrate thresholds configurable (WiFi/Cellular/LAN separate)
-- [ ] Add default playback quality user preference
-- [ ] Add adaptive bitrate during playback (detect buffering, auto-reduce quality)
-- [ ] Unify codec detection logic (3 separate implementations → 1 source of truth)
+- [x] Make bitrate thresholds configurable (WiFi/Cellular/LAN separate)
+- [x] Add default playback quality user preference
+- [x] Add adaptive bitrate during playback (detect buffering, auto-reduce quality)
+- [x] Unify codec detection logic (3 separate implementations → 1 source of truth)
 
 Files: `data/playback/EnhancedPlaybackManager.kt`, `ui/player/VideoPlayerViewModel.kt`, `data/DeviceCapabilities.kt`
 
@@ -102,10 +102,10 @@ Files: `data/playback/EnhancedPlaybackManager.kt`, `ui/player/VideoPlayerViewMod
 **Priority**: Medium | **Effort**: 2-3 days
 
 Tasks:
-- [ ] Replace string-matching fallback detection with ExoPlayer error codes
-- [ ] Distinguish codec errors vs bitrate errors vs resolution errors
-- [ ] Allow multiple fallback attempts (currently limited to 1)
-- [ ] Try lower quality before switching to full transcoding
+- [x] Replace string-matching fallback detection with ExoPlayer error codes
+- [x] Distinguish codec errors vs bitrate errors vs resolution errors
+- [x] Allow multiple fallback attempts (currently limited to 1)
+- [x] Try lower quality before switching to full transcoding
 
 Files: `ui/player/VideoPlayerViewModel.kt`
 
@@ -171,10 +171,10 @@ Tasks:
 ### 3.0 Security & Reliability
 **Priority**: High | **Effort**: 5-7 days
 
-> **Full Details**: [docs/IMPROVEMENT_PLAN.md - Phase B & C](docs/IMPROVEMENT_PLAN.md#phase-b-security-hardening-high)
+> **Full Details**: [IMPROVEMENT_PLAN.md - Phase B & C](IMPROVEMENT_PLAN.md#phase-b-security-hardening-high)
 
 Tasks:
-- [ ] Remove API tokens from URL query parameters (CWE-598) - use Authorization header
+- [x] Remove API tokens from URL query parameters (CWE-598) - use Authorization header
 - [ ] Restrict cleartext HTTP to RFC 1918 private networks only
 - [ ] Add progress sync resilience for network drops (queue and retry)
 - [ ] Fix Cast session initialization race condition
@@ -236,7 +236,7 @@ Target: 70%+ for ViewModels and Repositories
 
 ## Known Limitations
 
-> **Note**: For detailed bug tracking with workarounds, see [KNOWN_ISSUES.md](KNOWN_ISSUES.md)
+> **Note**: For detailed bug tracking with workarounds, see [KNOWN_ISSUES.md](../features/KNOWN_ISSUES.md)
 
 ### Material 3 Components
 - **Carousel**: Using official Material 3 carousel API via `HorizontalUncontainedCarousel`
@@ -290,7 +290,7 @@ When completing a task:
 
 ## Related Documentation
 
-- [docs/IMPROVEMENT_PLAN.md](docs/IMPROVEMENT_PLAN.md) - Detailed technical improvement plan (transcoding, security, accessibility)
+- [IMPROVEMENT_PLAN.md](IMPROVEMENT_PLAN.md) - Detailed technical improvement plan (transcoding, security, accessibility)
 - [CLAUDE.md](CLAUDE.md) - Development guidelines
 - [CONTRIBUTING.md](CONTRIBUTING.md) - Contribution process
 - [MATERIAL3_EXPRESSIVE.md](MATERIAL3_EXPRESSIVE.md) - M3 Expressive components


### PR DESCRIPTION
### Motivation
- Make planning and issue-tracking docs tell one coherent story by eliminating contradictory statuses across `CURRENT_STATUS.md`, `ROADMAP.md`, `KNOWN_ISSUES.md`, and `IMPROVEMENT_PLAN.md`.
- Treat already-shipped work (notably Offline Downloads and the Transcoding/Playback overhaul) as completed baseline while preserving follow-up hardening tasks in the Improvement Plan.
- Ensure every open user-facing issue points to a single canonical implementation plan and require docs updates when features ship.

### Description
- Added a canonical "Feature Truth Table" to `docs/plans/CURRENT_STATUS.md` and aligned its header to `Last verified on: 2026-04-22` so it is the single source of status truth.
- Updated `docs/plans/ROADMAP.md` to mark Offline Downloads and the Phase 1.5 Transcoding & Playback work as completed, converted checklist items to checked where appropriate, and aligned the header date.
- Reworked `docs/features/KNOWN_ISSUES.md` to: reframe Offline Downloads as "reliability edge cases" (not unimplemented), add a `Canonical Plan` pointer on open issues, fix cross-links, and set the shared verification date.
- Updated `docs/plans/IMPROVEMENT_PLAN.md` with the same verification date, corrected plan links, and added a short status-alignment note that the overhaul + downloads are baseline complete.
- Added a lightweight documentation-maintenance checklist to `docs/development/CONTRIBUTING.md` requiring synchronized status/roadmap/issue/improvement-plan updates and matching `Last verified on` dates when features ship.

### Testing
- Ran `git diff --check` to validate there are no whitespace/patch errors and it returned clean results (no warnings).
- Performed content verification via `rg`/file inspection to confirm `Last verified on: 2026-04-22` appears in the four modified files and that internal cross-links were updated.
- No runtime or unit-test changes were required because this PR only updates documentation files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e95917408083278ca62e62d338f34c)