### PR TITLE
Docs: add subtitle issue and refresh ROADMAP (dates, priorities, prefs)

### DIFF
--- a/docs/features/KNOWN_ISSUES.md
+++ b/docs/features/KNOWN_ISSUES.md
@@ -1,6 +1,6 @@
 # Jellyfin Android - Known Issues
 
-**Last verified on**: 2026-04-22
+**Last verified on**: 2026-04-23
 
 This document tracks user-facing bugs, workarounds, and fix status. For technical debt and code quality improvements, see [docs/plans/IMPROVEMENT_PLAN.md](../plans/IMPROVEMENT_PLAN.md). For feature status, see [CURRENT_STATUS.md](../plans/CURRENT_STATUS.md). For planned features, see [ROADMAP.md](../plans/ROADMAP.md).
 
@@ -127,9 +127,32 @@ private fun backoff(attempt: Int) {
 
 ---
 
+### #8: Subtitle Feature Gaps (External + Styling + Sync)
+
+**Impact**: Incomplete subtitle experience for users with external subtitle files and styled subtitle formats
+**Affected Users**: Users needing external subtitles, ASS/SSA styling, or timing adjustments
+**Files**:
+- `app/src/main/java/com/rpeters/jellyfin/ui/player/VideoPlayerViewModel.kt`
+
+**Details**:
+- External subtitle support remains incomplete
+- ASS/SSA styling may be lost when converted/rendered as simpler formats
+- No in-player subtitle sync delay setting for manual correction
+
+**Workaround**:
+- Use embedded server subtitles where available
+- Prefer content with pre-synced subtitles
+
+**Fix Status**: 🔜 Planned
+**Canonical Plan**: [ROADMAP §1.6.1](../plans/ROADMAP.md#161-subtitle-system)
+**Target**: Subtitle system improvements
+**Effort**: 3-5 days
+
+---
+
 ## 🟢 LOW PRIORITY Issues (Minor Issues)
 
-### #8: Large Composables Impact Recomposition Performance
+### #9: Large Composables Impact Recomposition Performance
 
 **Impact**: Slower UI updates, increased memory during recomposition
 **Affected Users**: All users (noticeable on lower-end devices)
@@ -155,7 +178,7 @@ private fun backoff(attempt: Int) {
 
 ---
 
-### #9: Build Warnings (~150 Warnings)
+### #10: Build Warnings (~150 Warnings)
 
 **Impact**: Developer experience, potential future issues
 **Affected Users**: Developers only
@@ -179,7 +202,7 @@ private fun backoff(attempt: Int) {
 
 ---
 
-### #10: Android TV D-Pad Navigation Not Fully Tested
+### #11: Android TV D-Pad Navigation Not Fully Tested
 
 **Impact**: Potential navigation issues on Android TV
 **Affected Users**: Android TV users

--- a/docs/plans/ROADMAP.md
+++ b/docs/plans/ROADMAP.md
@@ -1,6 +1,6 @@
 # Jellyfin Android - Roadmap
 
-**Last verified on**: 2026-04-22
+**Last verified on**: 2026-04-23
 
 > **Quick Links**: [Feature Status](CURRENT_STATUS.md) | [Known Issues](../features/KNOWN_ISSUES.md) | [Upgrade Path](UPGRADE_PATH.md)
 
@@ -128,12 +128,29 @@ Files: `ui/player/VideoPlayerViewModel.kt`
 **Priority**: Medium | **Effort**: 3-5 days
 
 Tasks:
-- [ ] Add preferred audio language setting (currently hardcoded to English)
-- [ ] Add auto-play next episode toggle with configurable countdown
+- [x] Add preferred audio language setting
+- [x] Add auto-play next episode toggle with configurable countdown
 - [ ] Add auto-skip intro/outro preference
-- [ ] Add resume playback mode (Always/Ask/Never)
+- [x] Add resume playback mode (Always/Ask/Never)
 
 Files: `ui/player/VideoPlayerViewModel.kt`, new DataStore preferences
+
+Status note:
+- Playback preferences are now mostly complete.
+- Remaining gap: auto-skip intro/outro preference and UI behavior wiring.
+
+---
+
+## New Priority List (Q2 2026 Refresh)
+
+Based on current shipped capabilities and open reliability gaps, this is the recommended near-term execution order:
+
+1. **Music background playback completion** (MediaSession + notification/lockscreen controls)
+2. **Auth interceptor non-blocking refresh** (remove `runBlocking` + `Thread.sleep` path)
+3. **Android TV D-pad hardening** (focus dead-ends and remote-only journeys)
+4. **Offline downloads reliability validation** (OEM background limits + long-run retries)
+5. **Subtitle system upgrades** (external subtitles, ASS/SSA styling, sync delay)
+6. **Accessibility and empty states sweep** (TalkBack content descriptions + retry UX)
 
 ---
 


### PR DESCRIPTION
### Motivation
- Make known issues and roadmap reflect recent findings about subtitle support and playback preferences progress.
- Surface an explicit high-priority item for subtitle gaps so it is tracked alongside casting and download reliability issues.
- Update verification dates and near-term priorities to match a Q2 2026 refresh.

### Description
- Updated verification dates from `2026-04-22` to `2026-04-23` in `docs/features/KNOWN_ISSUES.md` and `docs/plans/ROADMAP.md`.
- Added a new high-priority entry `#8: Subtitle Feature Gaps (External + Styling + Sync)` to `KNOWN_ISSUES.md` documenting external subtitle, ASS/SSA styling, and sync delay gaps. 
- Renumbered subsequent low-priority issues in `KNOWN_ISSUES.md` to account for the insertion, and adjusted the playback preferences section in `ROADMAP.md` to mark some items (`preferred audio language`, `auto-play next episode`, `resume playback mode`) as completed and added a short status note. 
- Introduced a `New Priority List (Q2 2026 Refresh)` in `ROADMAP.md` to clarify the near-term execution order including subtitle system upgrades.

### Testing
- No automated tests were run because this change is documentation-only and contains no code modifications.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e936e96c8c8327a89c408f38cc153e)