### PR TITLE
fix: fallback home hero carousel to TV shows when movies missing

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/home/ImmersiveHomeSections.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/home/ImmersiveHomeSections.kt
@@ -79,18 +79,22 @@ internal fun MobileExpressiveHomeContent(
         ),
         verticalArrangement = Arrangement.spacedBy(20.dp),
     ) {
-        val heroMovies = contentLists.recentMovies.take(5)
-        if (heroMovies.isNotEmpty() || appState.isLoading) {
+        val heroItems = if (contentLists.recentMovies.isNotEmpty()) {
+            contentLists.recentMovies.take(5)
+        } else {
+            contentLists.recentTVShows.take(5)
+        }
+        if (heroItems.isNotEmpty() || appState.isLoading) {
             item(key = "recently_added_hero", contentType = "hero_row") {
-                if (heroMovies.isNotEmpty()) {
-                    val featuredItems = remember(heroMovies, unknownText) {
-                        heroMovies.map { movie ->
+                if (heroItems.isNotEmpty()) {
+                    val featuredItems = remember(heroItems, unknownText) {
+                        heroItems.map { item ->
                             CarouselItem(
-                                id = movie.id.toString(),
-                                title = movie.name ?: unknownText,
-                                subtitle = movie.productionYear?.toString() ?: "",
-                                imageUrl = getBackdropUrl(movie) ?: getImageUrl(movie) ?: "",
-                                type = MediaType.MOVIE,
+                                id = item.id.toString(),
+                                title = item.name ?: unknownText,
+                                subtitle = item.productionYear?.toString() ?: "",
+                                imageUrl = getBackdropUrl(item) ?: getImageUrl(item) ?: "",
+                                type = if (item.type == BaseItemKind.SERIES) MediaType.TV_SHOW else MediaType.MOVIE,
                             )
                         }
                     }
@@ -98,10 +102,10 @@ internal fun MobileExpressiveHomeContent(
                     ImmersiveHeroCarousel(
                         items = featuredItems,
                         onItemClick = { selected ->
-                            heroMovies.firstOrNull { it.id.toString() == selected.id }?.let(onItemClick)
+                            heroItems.firstOrNull { it.id.toString() == selected.id }?.let(onItemClick)
                         },
                         onPlayClick = { selected ->
-                            heroMovies.firstOrNull { it.id.toString() == selected.id }?.let(onItemClick)
+                            heroItems.firstOrNull { it.id.toString() == selected.id }?.let(onItemClick)
                         },
                         modifier = Modifier.fillMaxWidth(),
                     )


### PR DESCRIPTION
### Motivation
- Ensure the home hero carousel shows meaningful content when the movie library is empty by falling back to recently added TV shows. 
- Preserve existing click/play behavior while correctly typing fallback items as TV shows so UI and playback can behave appropriately.

### Description
- Changed hero selection in `ImmersiveHomeSections.kt` to build a unified `heroItems` list that prefers `contentLists.recentMovies` and falls back to `contentLists.recentTVShows` when no movies exist. 
- Updated carousel mapping to use the generic `item` variable and set `type = if (item.type == BaseItemKind.SERIES) MediaType.TV_SHOW else MediaType.MOVIE` so TV show entries are typed correctly. 
- Updated click and play handlers to resolve selections against the new `heroItems` list so interactions continue to work with the fallback data.

### Testing
- Ran `./gradlew :app:compileDebugKotlin`, which failed to compile in this environment because the Android Gradle Plugin `com.android.application:9.2.0` could not be resolved from configured repositories. 
- No further automated tests (unit/instrumentation) were executed in this environment due to the compile failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efac13633083279012129c5dee4f86)