### PR TITLE
Require confirmation before deleting downloads and offline content

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/ui/downloads/DownloadsScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/downloads/DownloadsScreen.kt
@@ -56,6 +56,7 @@ fun DownloadsScreen(
     var showDeleteAllConfirmation by remember { mutableStateOf(false) }
     var showClearWatchedConfirmation by remember { mutableStateOf(false) }
     var redownloadTarget by remember { mutableStateOf<OfflineDownload?>(null) }
+    var deleteTarget by remember { mutableStateOf<OfflineDownload?>(null) }
 
     if (showDeleteAllConfirmation) {
         AlertDialog(
@@ -95,6 +96,36 @@ fun DownloadsScreen(
             },
             dismissButton = {
                 TextButton(onClick = { }) {
+                    Text(stringResource(id = R.string.cancel))
+                }
+            },
+        )
+    }
+
+    deleteTarget?.let { target ->
+        AlertDialog(
+            onDismissRequest = { deleteTarget = null },
+            title = { Text(stringResource(id = R.string.library_actions_delete_confirm_title)) },
+            text = {
+                Text(
+                    stringResource(
+                        id = R.string.library_actions_delete_confirm_message,
+                        target.itemName,
+                    ),
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        downloadsViewModel.deleteDownload(target.id)
+                        deleteTarget = null
+                    },
+                ) {
+                    Text(stringResource(id = R.string.delete))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { deleteTarget = null }) {
                     Text(stringResource(id = R.string.cancel))
                 }
             },
@@ -216,7 +247,7 @@ fun DownloadsScreen(
                     onPause = { downloadsViewModel.pauseDownload(download.id) },
                     onResume = { downloadsViewModel.resumeDownload(download.id) },
                     onCancel = { downloadsViewModel.cancelDownload(download.id) },
-                    onDelete = { downloadsViewModel.deleteDownload(download.id) },
+                    onDelete = { deleteTarget = download },
                     onRedownload = { },
                     onOpenDetail = { onOpenItemDetail(download) },
                     onPlay = { downloadsViewModel.playOfflineContent(download.jellyfinItemId) },

--- a/app/src/main/java/com/rpeters/jellyfin/ui/downloads/DownloadsScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/downloads/DownloadsScreen.kt
@@ -32,10 +32,9 @@ import com.rpeters.jellyfin.data.offline.VideoQuality
 import com.rpeters.jellyfin.ui.components.ExpressiveBackNavigationIcon
 import com.rpeters.jellyfin.ui.components.ExpressiveContentCard
 import com.rpeters.jellyfin.ui.components.ExpressiveFilledButton
+import com.rpeters.jellyfin.ui.components.ExpressiveSwitchListItem
 import com.rpeters.jellyfin.ui.components.ExpressiveTopAppBar
 import com.rpeters.jellyfin.ui.components.ExpressiveTopAppBarAction
-import com.rpeters.jellyfin.ui.components.ExpressiveSwitchListItem
-import com.rpeters.jellyfin.ui.components.ExpressiveWavyLinearLoading
 import com.rpeters.jellyfin.ui.components.ExpressiveWavyLinearProgress
 import com.rpeters.jellyfin.ui.theme.JellyfinExpressiveTheme
 import kotlin.math.roundToInt
@@ -188,7 +187,7 @@ fun DownloadsScreen(
                         onClick = { },
                         enabled = downloads.isNotEmpty(),
                     )
-                }
+                },
             )
         },
     ) { paddingValues ->

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/OfflineScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/OfflineScreen.kt
@@ -133,7 +133,9 @@ private fun ConnectivityStatusCard(
     isOnline: Boolean,
     networkType: NetworkType,
     modifier: Modifier = Modifier,
-) {
+ ) {
+    var deleteTarget by remember { mutableStateOf<BaseItemDto?>(null) }
+
     Card(
         modifier = modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(
@@ -253,6 +255,7 @@ private fun OfflineContentSection(
     onDeleteContent: (BaseItemDto) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    var deleteTarget by remember { mutableStateOf<BaseItemDto?>(null) }
     Card(
         modifier = modifier.fillMaxWidth(),
     ) {
@@ -310,13 +313,44 @@ private fun OfflineContentSection(
                         OfflineContentItem(
                             libraryItem = libraryItem,
                             onPlay = { onPlayContent(libraryItem.item) },
-                            onDelete = { onDeleteContent(libraryItem.item) },
+                            onDelete = { deleteTarget = libraryItem.item },
                         )
                     }
                 }
             }
         }
     }
+
+    deleteTarget?.let { item ->
+        AlertDialog(
+            onDismissRequest = { deleteTarget = null },
+            title = { Text(stringResource(id = R.string.library_actions_delete_confirm_title)) },
+            text = {
+                Text(
+                    stringResource(
+                        id = R.string.library_actions_delete_confirm_message,
+                        item.name ?: stringResource(id = R.string.unknown),
+                    ),
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        onDeleteContent(item)
+                        deleteTarget = null
+                    },
+                ) {
+                    Text(stringResource(id = R.string.delete))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { deleteTarget = null }) {
+                    Text(stringResource(id = R.string.cancel))
+                }
+            },
+        )
+    }
+
 }
 
 @Composable

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/OfflineScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/OfflineScreen.kt
@@ -133,7 +133,7 @@ private fun ConnectivityStatusCard(
     isOnline: Boolean,
     networkType: NetworkType,
     modifier: Modifier = Modifier,
- ) {
+) {
     var deleteTarget by remember { mutableStateOf<BaseItemDto?>(null) }
 
     Card(
@@ -350,7 +350,6 @@ private fun OfflineContentSection(
             },
         )
     }
-
 }
 
 @Composable


### PR DESCRIPTION
### Motivation
- Prevent accidental removal of media by requiring an explicit confirmation before any per-item delete action in the Downloads and Offline Content screens. 

### Description
- Added a `deleteTarget` state to `DownloadsScreen` and show an `AlertDialog` using `R.string.library_actions_delete_confirm_title`/`..._message` which calls `downloadsViewModel.deleteDownload` only after the user confirms.  
- Rewired per-item delete callbacks in the downloads list to set `deleteTarget` instead of immediately deleting.  
- Added a `deleteTarget` state to `OfflineContentSection` (in `OfflineScreen`) and present the same confirmation dialog which calls the provided `onDeleteContent` only on confirmation.  
- Modified files: `app/src/main/java/com/rpeters/jellyfin/ui/downloads/DownloadsScreen.kt` and `app/src/main/java/com/rpeters/jellyfin/ui/screens/OfflineScreen.kt` to implement the flow and reuse existing string resources for titles/buttons.

### Testing
- Ran `./gradlew :app:compileDebugKotlin` in this environment which failed due to inability to resolve the Android Gradle plugin (`com.android.application` 9.2.0) from configured repositories, so a full build could not be validated here.  
- No other automated unit or instrumentation tests were executed as part of this change in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9120f6e408327b772b38583e24c84)