### PR TITLE
fix: load and apply selected app font in Appearance settings

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/data/preferences/ThemePreferencesRepository.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/data/preferences/ThemePreferencesRepository.kt
@@ -66,6 +66,10 @@ open class ThemePreferencesRepository(
                     value = preferences[PreferencesKeys.CONTRAST_LEVEL],
                     default = defaults.contrastLevel,
                 ),
+                appFont = parseEnum(
+                    value = preferences[PreferencesKeys.APP_FONT],
+                    default = defaults.appFont,
+                ),
                 useThemedIcon = preferences[PreferencesKeys.USE_THEMED_ICON]
                     ?: defaults.useThemedIcon,
                 enableEdgeToEdge = preferences[PreferencesKeys.ENABLE_EDGE_TO_EDGE]


### PR DESCRIPTION
### Motivation
- Appearance > Typography selections appeared to do nothing because the saved `APP_FONT` value was never read back into `ThemePreferences`, so the UI always used the default font.

### Description
- Read and map `APP_FONT` from DataStore into `ThemePreferences` by adding `appFont = parseEnum(value = preferences[PreferencesKeys.APP_FONT], default = defaults.appFont)` in `app/src/main/java/com/rpeters/jellyfin/data/preferences/ThemePreferencesRepository.kt`.

### Testing
- Ran `./gradlew testDebugUnitTest --no-daemon`, which failed in this environment because the Android Gradle plugin `com.android.application:9.2.0` could not be resolved from the configured repositories, so unit tests could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9145862a483279e871ebd82ccd9a4)