### PR TITLE
docs: refresh README project status for May 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ Automated workflows for:
 
 ## 📊 Project Status
 
-### **What's Working Now (April 2026)** ✅
+### **What's Working Now (May 2026)** ✅
 
 | Feature | Status |
 |---------|--------|
@@ -361,6 +361,7 @@ Automated workflows for:
 |---------|--------|
 | Music Background Playback (notification, lock-screen controls) | 🔄 In Progress |
 | Android TV D-pad navigation & focus polish | 🔄 In Progress |
+| Expanded instrumentation test coverage for playback + casting flows | 🔄 In Progress |
 
 ### **Planned** 📋
 
@@ -372,6 +373,8 @@ Automated workflows for:
 | Home Screen Widgets | Low |
 
 **[📖 See detailed roadmap in docs/plans/ROADMAP.md](docs/plans/ROADMAP.md)**
+
+> Last README status refresh: **May 22, 2026 (UTC)**. For the source-of-truth matrix, see **[docs/plans/CURRENT_STATUS.md](docs/plans/CURRENT_STATUS.md)**.
 
 ---
 


### PR DESCRIPTION
### Motivation
- Keep the `README.md` project status current and direct readers to the canonical status matrix in `docs/plans/CURRENT_STATUS.md`.

### Description
- Updated the Project Status heading to May 2026, added an `In Progress` line for "Expanded instrumentation test coverage for playback + casting flows", and inserted a timestamped status refresh note pointing to `docs/plans/CURRENT_STATUS.md`.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1087bb41008327a6f0e5f5bf665296)