### PR TITLE
docs: refresh Jellyfin Android documentation index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,71 +1,118 @@
 # Jellyfin Android Documentation Index
 
-Welcome to the central documentation repository for the Jellyfin Android client. This index helps you navigate the various technical summaries, design plans, and development guides.
+Welcome to the central documentation repository for the Jellyfin Android client. This index maps current planning docs, feature write-ups, and development guides.
 
 ## 🚀 Features & UI Improvements
-*Immersive UI, Expressive Design, and specialized feature documentation.*
+*Immersive UI, AI features, playback updates, and user-facing enhancements.*
 
 - [Adaptive Navigation Summary](features/ADAPTIVE_NAVIGATION_SUMMARY.md)
+- [AI Enhanced Recommendations](features/AI_ENHANCED_RECOMMENDATIONS.md)
 - [AI Multimodal Integration](features/AI_MULTIMODAL.md)
+- [AI Person Bio Feature](features/AI_PERSON_BIO_FEATURE.md)
 - [Chromecast Unified Plan](features/CAST_SYSTEM_UNIFIED_PLAN.md)
 - [Feature Flags Summary](features/feature-flags-summary.md)
 - [Homescreen Tablet Summary](features/HOMESCREEN_TABLET_SUMMARY.md)
+- [Immersive UI Bugs](features/Immersive%20UI%20Bugs.md)
 - [Immersive UI Fixes](features/IMMERSIVE_UI_FIXES.md)
 - [Immersive UI Performance](features/IMMERSIVE_UI_PERFORMANCE.md)
 - [Immersive UI Progress](features/IMMERSIVE_UI_PROGRESS.md)
 - [Immersive UI Screenshot Review](features/IMMERSIVE_UI_SCREENSHOT_REVIEW.md)
+- [Known Issues](features/KNOWN_ISSUES.md)
 - [Material3 Expressive Design](features/MATERIAL3_EXPRESSIVE.md)
+- [Media Info UI Redesign](features/MEDIA_INFO_UI_REDESIGN.md)
 - [Movies Screen Improvements](features/MOVIES_SCREEN_IMPROVEMENTS.md)
+- [Offline Downloads Plan](features/OFFLINE_DOWNLOADS_PLAN.md)
+- [Person Detail Screen](features/PERSON_DETAIL_SCREEN.md)
+- [Quality Recommendation Fix](features/QUALITY_RECOMMENDATION_FIX.md)
 - [Tablet Improvements](features/TABLET_IMPROVEMENTS.md)
 - [Testing Immersive UI](features/TESTING_IMMERSIVE_UI.md)
 - [Transcoding Diagnostics Guide](features/TRANSCODING_DIAGNOSTICS_GUIDE.md)
 - [Transcoding Fix Diagram](features/TRANSCODING_FIX_DIAGRAM.md)
 - [Transcoding Fix Summary](features/TRANSCODING_FIX_SUMMARY.md)
-- [TV Roadmap](plans/TV_ROADMAP.md)
+- [Transcoding Review](features/TRANSCODING_REVIEW.md)
+- [TV Detail Notes](features/tv%20detail.md)
 - [TV Detail Upgrades Review](features/TV_DETAIL_UPGRADES_REVIEW.md)
 - [TV Shows Screen Improvements](features/TV_SHOWS_SCREEN_IMPROVEMENTS.md)
 
 ## 📅 Project Plans & Roadmap
-*Milestones, session summaries, and the path forward.*
+*Milestones, architecture plans, modernization tracks, and implementation summaries.*
 
 - [Roadmap](plans/ROADMAP.md)
-- [TV Roadmap](plans/TV_ROADMAP.md)
 - [Current Status](plans/CURRENT_STATUS.md)
 - [Phase 2 Completion Summary](plans/PHASE_2_COMPLETION_SUMMARY.md)
 - [Phase 3 Progress](plans/PHASE_3_PROGRESS.md)
- - [2026-03-16 Upgrade Plan](plans/2026-03-16-upgrade-plan.md)
- - [Phase 5 Status](plans/PHASE_5_STATUS.md)
- - [Session 1 Fixes Summary](plans/SESSION_1_FIXES_SUMMARY.md)
- - [Session 2 Material Icons Summary](plans/SESSION_2_MATERIAL_ICONS_SUMMARY.md)
- - [Session 3 Detail Polish Summary](plans/SESSION_3_DETAIL_POLISH_SUMMARY.md)
- - [UI Plan](plans/ui%20plan.md)
- - [Upgrade Path](plans/UPGRADE_PATH.md)
+- [Phase 5 Status](plans/PHASE_5_STATUS.md)
+- [Android 16/17 Readiness](plans/ANDROID_16_17_READINESS.md)
+- [Android 16/17 Modernization](plans/2026-03-28-android-16-17-modernization.md)
+- [Android 16/17 Modernization Phase 2](plans/2026-04-26-android-16-17-modernization-phase-2.md)
+- [Android TV Modernization Plan](plans/ANDROID_TV_MODERNIZATION_PLAN.md)
+- [AI Integration Opportunities](plans/AI_INTEGRATION_OPPORTUNITIES.md)
+- [Chromecast Rebuild Plan](plans/CHROMECAST_REBUILD_PLAN.md)
+- [Cinefin Server Plugin Architecture](plans/CINEFIN_SERVER_PLUGIN_ARCHITECTURE.md)
+- [Improvement Plan](plans/IMPROVEMENT_PLAN.md)
+- [Improvement System](plans/IMPROVEMENT_SYSTEM.md)
+- [Navigation3 Evaluation](plans/NAVIGATION3_EVALUATION.md)
+- [Offline Startup](plans/OFFLINE_STARTUP.md)
+- [TV Focus Contracts](plans/TV_FOCUS_CONTRACTS.md)
+- [TV Roadmap](plans/TV_ROADMAP.md)
+- [Upgrade Path](plans/UPGRADE_PATH.md)
+- [Upgrade Path (2026-03-16)](plans/2026-03-16-upgrade-path.md)
+- [Upgrade Plan (2026-03-16)](plans/2026-03-16-upgrade-plan.md)
+- [Video Playback Transcoding Device Plan](plans/VIDEO_PLAYBACK_TRANSCODING_DEVICE_PLAN.md)
+- [Visual Polish and Delight](plans/2026-03-28-visual-polish-and-delight.md)
+- [Jellyfin Repository Refactor Status](plans/2026-03-30-jellyfin-repository-refactor-status.md)
+- [TV Login + Home Video](plans/2026-02-20-tv-login-homevideo.md)
+- [TV Login + Home Video Design](plans/2026-02-20-tv-login-homevideo-design.md)
+- [TV Surgical Fixes](plans/2026-02-20-tv-surgical-fixes.md)
+- [TV Surgical Fixes Design](plans/2026-02-20-tv-surgical-fixes-design.md)
+- [Transcoding Progress](plans/2026-02-21-transcoding-progress.md)
+- [Transcoding Progress Design](plans/2026-02-21-transcoding-progress-design.md)
+- [Offline Download Bug Fixes](plans/2026-02-22-offline-download-bug-fixes.md)
+- [Immersive Library Screens Refactor](plans/2026-02-24-immersive-library-screens-refactor.md)
+- [Immersive Library Screens Refactor Design](plans/2026-02-24-immersive-library-screens-refactor-design.md)
+- [Quick Wins Complete](plans/QUICK_WINS_COMPLETE.md)
+- [Quick Wins Implementation Summary](plans/QUICK_WINS_IMPLEMENTATION_SUMMARY.md)
+- [Session 1 Fixes Summary](plans/SESSION_1_FIXES_SUMMARY.md)
+- [Session 2 Material Icons Summary](plans/SESSION_2_MATERIAL_ICONS_SUMMARY.md)
+- [Session 3 Detail Polish Summary](plans/SESSION_3_DETAIL_POLISH_SUMMARY.md)
 - [Session 4 TV Show Polish Summary](plans/SESSION_4_TV_SHOW_POLISH_SUMMARY.md)
+- [Session 5 Final Cleanup Summary](plans/SESSION_5_FINAL_CLEANUP_SUMMARY.md)
 - [Session 5.5 Complete Summary](plans/SESSION_5.5_COMPLETE_SUMMARY.md)
+- [Session 5.5 Detail Screens Fix Summary](plans/SESSION_5.5_DETAIL_SCREENS_FIX_SUMMARY.md)
 - [Session 5.5 Episode Count Fix](plans/SESSION_5.5_EPISODE_COUNT_FIX.md)
+- [UI Plan](plans/ui%20plan.md)
 
 ## 🛠️ Development & Engineering
-*Developer guides, setup instructions, and architecture analysis.*
+*Developer guides, setup instructions, analysis docs, and implementation notes.*
 
 - [Agents Configuration](development/AGENTS.md)
 - [AI Quickstart](development/AI_QUICKSTART.md)
 - [AI Setup](development/AI_SETUP.md)
+- [Android 15 Opportunities for Cinefin](development/ANDROID_15_OPPORTUNITIES_FOR_CINEFIN.md)
 - [Contributing Guidelines](development/CONTRIBUTING.md)
 - [Crash Investigation Report](development/CRASH_INVESTIGATION_REPORT.md)
 - [Device Compatibility](development/DEVICE_COMPATIBILITY.md)
 - [Firebase App Check Setup](development/FIREBASE_APP_CHECK_SETUP.md)
 - [Firebase Feature Flags Guide](development/FIREBASE_FEATURE_FLAGS_GUIDE.md)
+- [Fixes Summary (2026-02-08)](development/FIXES_SUMMARY_2026-02-08.md)
+- [Predictive Back Animations Plan](development/PREDICTIVE_BACK_ANIMATIONS_PLAN.md)
 - [Testing Guide](development/TESTING_GUIDE.md)
 - [Testing Dispatcher Pattern](development/TESTING_DISPATCHER_PATTERN.md)
+- [Testing Improvement Plan](development/TESTING_IMPROVEMENT_PLAN.md)
 - [Video Player Analysis](development/VIDEO_PLAYER_ANALYSIS.md)
 
 ## 🔒 Security & Privacy
-*Privacy policies and security audit summaries.*
+*Privacy and transport security documentation.*
 
 - [Privacy Policy (MD)](../privacy-policy.md)
 - [Privacy Policy (HTML)](../privacy-policy.html)
 - [TLS Fix Summary](security/TLS_FIX_SUMMARY.md)
 - [TLS Troubleshooting](security/TLS_TROUBLESHOOTING.md)
 
+## 🗃️ Archive
+*Historical documents retained for reference.*
+
+- [Archive Folder](archive/)
+
 ---
-*For archived documentation, see the [Archive folder](archive/).*
+If you add new docs in `docs/features`, `docs/plans`, `docs/development`, or `docs/security`, update this index in the same PR.


### PR DESCRIPTION
### Motivation
- Keep the central documentation index up-to-date so new markdown files added under `docs/features`, `docs/plans`, and `docs/development` are discoverable and contributors are reminded to update the index.

### Description
- Updated `docs/README.md` to add links for recently introduced feature, plan, and development documents, reword section descriptions, add an archive reference, and include a maintenance note to update the index when new docs are added.

### Testing
- No automated tests were required for this documentation-only update; no code changes were made.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15bad4e40c8327a5f3bf0b6f998091)