### PR TITLE
feat: Add admin-only access control for plugin credential import

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/data/JellyfinServer.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/data/JellyfinServer.kt
@@ -17,6 +17,7 @@ data class JellyfinServer(
     // Normalized server URL for credential lookups
     @SerialName("originalServerUrl")
     val normalizedUrl: String? = null,
+    val isAdministrator: Boolean = false,
 )
 
 @Serializable

--- a/app/src/main/java/com/rpeters/jellyfin/data/repository/CinefinPluginRepository.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/data/repository/CinefinPluginRepository.kt
@@ -11,6 +11,7 @@ import com.rpeters.jellyfin.data.repository.common.ErrorType
 import com.rpeters.jellyfin.utils.SecureLogger
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -75,6 +76,10 @@ class CinefinPluginRepository(
         return retryNetworkCall {
             try {
                 handleResponse(service.getCredentials())
+            } catch (e: SerializationException) {
+                // Server returned an unexpected response body (e.g. an error JSON for non-admin users)
+                SecureLogger.e(TAG, "Failed to parse plugin credentials response", e)
+                ApiResult.Error("Administrator access is required to import plugin credentials", e, ErrorType.FORBIDDEN)
             } catch (e: Exception) {
                 SecureLogger.e(TAG, "Failed to get plugin credentials", e)
                 ApiResult.Error("Network error syncing plugin credentials", e, ErrorType.NETWORK)

--- a/app/src/main/java/com/rpeters/jellyfin/data/repository/CinefinPluginRepository.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/data/repository/CinefinPluginRepository.kt
@@ -77,9 +77,15 @@ class CinefinPluginRepository(
             try {
                 handleResponse(service.getCredentials())
             } catch (e: SerializationException) {
-                // Server returned an unexpected response body (e.g. an error JSON for non-admin users)
                 SecureLogger.e(TAG, "Failed to parse plugin credentials response", e)
-                ApiResult.Error("Administrator access is required to import plugin credentials", e, ErrorType.FORBIDDEN)
+                val isAdmin = authRepository.currentServer.value?.isAdministrator == true
+                val message = if (isAdmin) {
+                    "Failed to parse plugin credentials. Please ensure the Cinefin plugin is up to date."
+                } else {
+                    "Administrator access is required to import plugin credentials"
+                }
+                val errorType = if (isAdmin) ErrorType.SERVER_ERROR else ErrorType.FORBIDDEN
+                ApiResult.Error(message, e, errorType)
             } catch (e: Exception) {
                 SecureLogger.e(TAG, "Failed to get plugin credentials", e)
                 ApiResult.Error("Network error syncing plugin credentials", e, ErrorType.NETWORK)

--- a/app/src/main/java/com/rpeters/jellyfin/data/repository/JellyfinAuthRepository.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/data/repository/JellyfinAuthRepository.kt
@@ -282,6 +282,7 @@ class JellyfinAuthRepository @Inject constructor(
             accessToken = authResult.accessToken,
             loginTimestamp = System.currentTimeMillis(),
             normalizedUrl = normalizedServerUrl,
+            isAdministrator = authResult.user?.policy?.isAdministrator == true,
         )
 
         _currentServer.update { server }

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/settings/MediaRequestSettingsScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/settings/MediaRequestSettingsScreen.kt
@@ -64,6 +64,7 @@ fun MediaRequestSettingsScreen(
     val radarrPrefs by viewModel.radarrPreferences.collectAsStateWithLifecycle()
     val radarrTestState by viewModel.radarrTestState.collectAsStateWithLifecycle()
     val credentialImportState by viewModel.credentialImportState.collectAsStateWithLifecycle()
+    val isCurrentUserAdmin by viewModel.isCurrentUserAdmin.collectAsStateWithLifecycle()
 
     Scaffold(
         topBar = {
@@ -90,7 +91,7 @@ fun MediaRequestSettingsScreen(
             ) {
                 ExpressiveFilledButton(
                     onClick = viewModel::importCredentialsFromPlugin,
-                    enabled = credentialImportState !is CredentialImportState.Importing,
+                    enabled = isCurrentUserAdmin && credentialImportState !is CredentialImportState.Importing,
                 ) {
                     if (credentialImportState is CredentialImportState.Importing) {
                         CircularProgressIndicator(
@@ -103,6 +104,14 @@ fun MediaRequestSettingsScreen(
                     } else {
                         Text("Import from Jellyfin")
                     }
+                }
+
+                if (!isCurrentUserAdmin) {
+                    Text(
+                        text = "Requires a Jellyfin administrator account",
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        style = MaterialTheme.typography.bodySmall,
+                    )
                 }
 
                 when (val state = credentialImportState) {

--- a/app/src/main/java/com/rpeters/jellyfin/ui/surface/components/ContinueWatchingWidget.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/surface/components/ContinueWatchingWidget.kt
@@ -10,8 +10,6 @@ import androidx.glance.Image
 import androidx.glance.ImageProvider
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.GlanceAppWidgetReceiver
-import androidx.glance.appwidget.lazy.LazyColumn
-import androidx.glance.appwidget.lazy.items
 import androidx.glance.appwidget.provideContent
 import androidx.glance.background
 import androidx.glance.layout.Alignment
@@ -30,7 +28,6 @@ import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
 import androidx.compose.ui.graphics.Color
 import com.rpeters.jellyfin.R
-import org.jellyfin.sdk.model.api.BaseItemDto
 
 class ContinueWatchingWidget : GlanceAppWidget() {
 
@@ -74,18 +71,15 @@ class ContinueWatchingWidget : GlanceAppWidget() {
 
             Spacer(modifier = GlanceModifier.height(12.dp))
 
-            // Placeholder list
-            LazyColumn(modifier = GlanceModifier.fillMaxSize()) {
-                item {
-                    Text(
-                        text = "Sign in to see your media",
-                        style = TextStyle(
-                            fontSize = 14.sp,
-                            color = androidx.glance.unit.ColorProvider(Color(0xFF888888))
-                        ),
-                        modifier = GlanceModifier.padding(vertical = 8.dp)
-                    )
-                }
+            Column(modifier = GlanceModifier.fillMaxSize()) {
+                Text(
+                    text = "Sign in to see your media",
+                    style = TextStyle(
+                        fontSize = 14.sp,
+                        color = androidx.glance.unit.ColorProvider(Color(0xFF888888))
+                    ),
+                    modifier = GlanceModifier.padding(vertical = 8.dp)
+                )
             }
         }
     }

--- a/app/src/main/java/com/rpeters/jellyfin/ui/surface/components/RecentlyAddedWidget.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/surface/components/RecentlyAddedWidget.kt
@@ -10,7 +10,6 @@ import androidx.glance.Image
 import androidx.glance.ImageProvider
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.GlanceAppWidgetReceiver
-import androidx.glance.appwidget.lazy.LazyColumn
 import androidx.glance.appwidget.provideContent
 import androidx.glance.background
 import androidx.glance.layout.Alignment
@@ -69,17 +68,15 @@ class RecentlyAddedWidget : GlanceAppWidget() {
 
             Spacer(modifier = GlanceModifier.height(12.dp))
 
-            LazyColumn(modifier = GlanceModifier.fillMaxSize()) {
-                item {
-                    Text(
-                        text = "New movies and shows will appear here",
-                        style = TextStyle(
-                            fontSize = 14.sp,
-                            color = androidx.glance.unit.ColorProvider(Color(0xFF888888))
-                        ),
-                        modifier = GlanceModifier.padding(vertical = 8.dp)
-                    )
-                }
+            Column(modifier = GlanceModifier.fillMaxSize()) {
+                Text(
+                    text = "New movies and shows will appear here",
+                    style = TextStyle(
+                        fontSize = 14.sp,
+                        color = androidx.glance.unit.ColorProvider(Color(0xFF888888))
+                    ),
+                    modifier = GlanceModifier.padding(vertical = 8.dp)
+                )
             }
         }
     }

--- a/app/src/main/java/com/rpeters/jellyfin/ui/viewmodel/MediaRequestSettingsViewModel.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/viewmodel/MediaRequestSettingsViewModel.kt
@@ -7,16 +7,19 @@ import com.rpeters.jellyfin.data.preferences.RadarrPreferences
 import com.rpeters.jellyfin.data.preferences.SeerrPreferences
 import com.rpeters.jellyfin.data.preferences.SeerrPreferencesRepository
 import com.rpeters.jellyfin.data.preferences.SonarrPreferences
+import com.rpeters.jellyfin.data.repository.IJellyfinAuthRepository
 import com.rpeters.jellyfin.data.repository.RadarrRepository
 import com.rpeters.jellyfin.data.repository.SonarrRepository
 import com.rpeters.jellyfin.data.repository.CinefinPluginRepository
 import com.rpeters.jellyfin.data.repository.SeerrRepository
 import com.rpeters.jellyfin.data.repository.common.ApiResult
+import com.rpeters.jellyfin.data.repository.common.ErrorType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -29,13 +32,24 @@ class MediaRequestSettingsViewModel @Inject constructor(
     private val sonarrRepository: SonarrRepository,
     private val radarrRepository: RadarrRepository,
     private val cinefinPluginRepository: CinefinPluginRepository,
+    private val authRepository: IJellyfinAuthRepository,
 ) : ViewModel() {
+
+    val isCurrentUserAdmin: StateFlow<Boolean> = authRepository.currentServer
+        .map { it?.isAdministrator == true }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
 
     private val _credentialImportState = MutableStateFlow<CredentialImportState>(CredentialImportState.Idle)
     val credentialImportState: StateFlow<CredentialImportState> = _credentialImportState.asStateFlow()
 
     fun importCredentialsFromPlugin() {
         if (_credentialImportState.value is CredentialImportState.Importing) return
+
+        if (authRepository.currentServer.value?.isAdministrator != true) {
+            _credentialImportState.value =
+                CredentialImportState.Failure("Administrator access is required to import plugin credentials")
+            return
+        }
 
         viewModelScope.launch {
             _credentialImportState.value = CredentialImportState.Importing
@@ -71,7 +85,12 @@ class MediaRequestSettingsViewModel @Inject constructor(
                 }
 
                 is ApiResult.Error -> {
-                    _credentialImportState.value = CredentialImportState.Failure(result.message)
+                    val message = when (result.errorType) {
+                        ErrorType.UNAUTHORIZED, ErrorType.FORBIDDEN ->
+                            "Administrator access is required to import plugin credentials"
+                        else -> result.message
+                    }
+                    _credentialImportState.value = CredentialImportState.Failure(message)
                 }
 
                 is ApiResult.Loading -> {

--- a/app/src/main/java/com/rpeters/jellyfin/ui/viewmodel/MediaRequestSettingsViewModel.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/viewmodel/MediaRequestSettingsViewModel.kt
@@ -86,8 +86,13 @@ class MediaRequestSettingsViewModel @Inject constructor(
 
                 is ApiResult.Error -> {
                     val message = when (result.errorType) {
-                        ErrorType.UNAUTHORIZED, ErrorType.FORBIDDEN ->
-                            "Administrator access is required to import plugin credentials"
+                        ErrorType.UNAUTHORIZED, ErrorType.FORBIDDEN -> {
+                            if (isCurrentUserAdmin.value) {
+                                "Session expired or access denied. Please try logging in again."
+                            } else {
+                                "Administrator access is required to import plugin credentials"
+                            }
+                        }
                         else -> result.message
                     }
                     _credentialImportState.value = CredentialImportState.Failure(message)

--- a/app/src/main/java/com/rpeters/jellyfin/ui/viewmodel/ServerConnectionViewModel.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/viewmodel/ServerConnectionViewModel.kt
@@ -67,6 +67,7 @@ object PreferencesKeys {
     val REMEMBER_LOGIN = booleanPreferencesKey("remember_login")
     val BIOMETRIC_AUTH_ENABLED = booleanPreferencesKey("biometric_auth_enabled") // New preference
     val BIOMETRIC_REQUIRE_STRONG = booleanPreferencesKey("biometric_require_strong")
+    val SESSION_IS_ADMIN = booleanPreferencesKey("session_is_admin")
 }
 
 @HiltViewModel
@@ -185,6 +186,7 @@ class ServerConnectionViewModel @Inject constructor(
                     // this, getImageUrl() can produce double-slash URLs (e.g. "server//Items/…")
                     // that the server rejects with 404, causing all images to fail after upgrade.
                     val normalizedSavedUrl = normalizeServerUrl(savedServerUrl)
+                    val savedIsAdmin = preferences[PreferencesKeys.SESSION_IS_ADMIN] ?: false
                     val restoredServer = JellyfinServer(
                         id = savedSessionServerId,
                         name = savedSessionServerName ?: savedUsername,
@@ -195,6 +197,7 @@ class ServerConnectionViewModel @Inject constructor(
                         accessToken = savedSessionToken,
                         loginTimestamp = restoredLoginTimestamp,
                         normalizedUrl = normalizedSavedUrl,
+                        isAdministrator = savedIsAdmin,
                     )
                     authRepository.restorePersistedSession(restoredServer)
                     _connectionState.value = _connectionState.value.copy(
@@ -596,6 +599,7 @@ class ServerConnectionViewModel @Inject constructor(
                 preferences.remove(PreferencesKeys.SESSION_SERVER_ID)
                 preferences.remove(PreferencesKeys.SESSION_SERVER_NAME)
                 preferences.remove(PreferencesKeys.SESSION_LOGIN_TIMESTAMP)
+                preferences.remove(PreferencesKeys.SESSION_IS_ADMIN)
             }
             if (currentState.savedServerUrl.isNotBlank() && currentState.savedUsername.isNotBlank()) {
                 secureCredentialManager.clearPassword(currentState.savedServerUrl, currentState.savedUsername)
@@ -616,6 +620,7 @@ class ServerConnectionViewModel @Inject constructor(
                 preferences.remove(PreferencesKeys.SESSION_SERVER_ID)
                 preferences.remove(PreferencesKeys.SESSION_SERVER_NAME)
                 preferences.remove(PreferencesKeys.SESSION_LOGIN_TIMESTAMP)
+                preferences.remove(PreferencesKeys.SESSION_IS_ADMIN)
             }
         }
     }
@@ -635,6 +640,7 @@ class ServerConnectionViewModel @Inject constructor(
                 preferences[PreferencesKeys.SESSION_SERVER_ID] = server.id
                 preferences[PreferencesKeys.SESSION_SERVER_NAME] = server.name
                 preferences[PreferencesKeys.SESSION_LOGIN_TIMESTAMP] = server.loginTimestamp ?: System.currentTimeMillis()
+                preferences[PreferencesKeys.SESSION_IS_ADMIN] = server.isAdministrator
             }
         }
     }


### PR DESCRIPTION
## Summary

Adds administrator-only access control for the plugin credential import feature in Media Request Settings. This prevents non-admin users from attempting to import credentials, which would fail at the API level anyway. The change includes:

- Tracks administrator status in `JellyfinServer` data class
- Exposes `isCurrentUserAdmin` StateFlow in `MediaRequestSettingsViewModel`
- Disables the import button and shows a helper message for non-admin users
- Handles `UNAUTHORIZED`/`FORBIDDEN` API errors with a user-friendly message
- Catches `SerializationException` in `CinefinPluginRepository` when the server returns an error response for non-admin requests

Also simplifies widget placeholder UI by replacing `LazyColumn` with `Column` in `ContinueWatchingWidget` and `RecentlyAddedWidget` (no functional change, just cleaner code).

## Type of change

- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no functional change)
- [ ] perf (performance improvement)
- [ ] test (add/fix tests)
- [ ] chore (build, tooling, deps)

## How to test

```bash
# Build
./gradlew assembleDebug

# Unit tests
./gradlew testDebugUnitTest

# Lint
./gradlew lintDebug
```

**Manual testing:**
1. Log in with a non-admin account
2. Navigate to Settings > Media Request Settings
3. Verify the "Import Credentials" button is disabled and shows "Requires a Jellyfin administrator account" message
4. Log in with an admin account
5. Verify the button is enabled and functional

## Checklist

- [x] Follows Conventional Commits
- [x] Branch named appropriately
- [x] Tests added/updated where applicable
- [x] `./gradlew testDebugUnitTest` passes
- [x] `./gradlew lintDebug` passes
- [x] Affected areas and testing notes included

https://claude.ai/code/session_01GoNtXZR2vu9ZUFJaEgYbWc