### PR TITLE
Improve Sonarr series lookup and add monitoring configuration

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/data/model/ArrModels.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/data/model/ArrModels.kt
@@ -1,7 +1,9 @@
 package com.rpeters.jellyfin.data.model
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.EncodeDefault
 
 // ── Sonarr models ────────────────────────────────────────────────────────────
 
@@ -64,14 +66,23 @@ data class SonarrAddSeriesRequest(
 
 @Serializable
 data class SonarrAddOptions(
+    // Tells Sonarr which seasons to monitor when the series is first added.
+    // "all" monitors all episodes within already-monitored seasons (per-season flags still control
+    // which seasons are active). Without this field Sonarr defaults to "unknown" and the series
+    // is added in an unmonitored state regardless of the seasons array.
+    @SerialName("monitor") val monitor: String = "all",
     @SerialName("searchForMissingEpisodes") val searchForMissingEpisodes: Boolean = true,
 )
 
+@OptIn(ExperimentalSerializationApi::class)
 @Serializable
 data class SonarrCommand(
     @SerialName("name") val name: String,
+    @EncodeDefault(EncodeDefault.Mode.NEVER)
     @SerialName("episodeIds") val episodeIds: List<Int> = emptyList(),
+    @EncodeDefault(EncodeDefault.Mode.NEVER)
     @SerialName("seriesId") val seriesId: Int? = null,
+    @EncodeDefault(EncodeDefault.Mode.NEVER)
     @SerialName("seasonNumber") val seasonNumber: Int? = null,
 )
 

--- a/app/src/main/java/com/rpeters/jellyfin/data/model/ArrModels.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/data/model/ArrModels.kt
@@ -64,12 +64,15 @@ data class SonarrAddSeriesRequest(
     @SerialName("images") val images: List<SonarrImage> = emptyList(),
 )
 
+@OptIn(ExperimentalSerializationApi::class)
 @Serializable
 data class SonarrAddOptions(
     // Tells Sonarr which seasons to monitor when the series is first added.
     // "all" monitors all episodes within already-monitored seasons (per-season flags still control
     // which seasons are active). Without this field Sonarr defaults to "unknown" and the series
     // is added in an unmonitored state regardless of the seasons array.
+    // ALWAYS encode this field so it reaches Sonarr regardless of the Json encodeDefaults setting.
+    @EncodeDefault(EncodeDefault.Mode.ALWAYS)
     @SerialName("monitor") val monitor: String = "all",
     @SerialName("searchForMissingEpisodes") val searchForMissingEpisodes: Boolean = true,
 )

--- a/app/src/main/java/com/rpeters/jellyfin/data/repository/SonarrRepository.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/data/repository/SonarrRepository.kt
@@ -298,6 +298,28 @@ class SonarrRepository @Inject constructor(
         }
     }
 
+    /**
+     * Resolves a TVDB ID when it isn't already known. Tries the `tmdb:` prefix first (faster,
+     * more precise), then falls back to a title search. Returns null if Sonarr isn't configured
+     * or no match is found.
+     */
+    suspend fun findTvdbId(title: String, tmdbId: Int? = null): Int? {
+        val (service, apiKey) = getService() ?: return null
+        return try {
+            if (tmdbId != null) {
+                val result = service.lookupSeriesByTvdb(apiKey, "tmdb:$tmdbId").body()
+                val id = result?.firstOrNull()?.tvdbId?.takeIf { it != 0 }
+                if (id != null) return id
+            }
+            val results = service.lookupSeriesByTvdb(apiKey, title).body() ?: return null
+            results.firstOrNull { it.title.equals(title, ignoreCase = true) }?.tvdbId?.takeIf { it != 0 }
+                ?: results.firstOrNull()?.tvdbId?.takeIf { it != 0 }
+        } catch (e: Exception) {
+            SecureLogger.w(TAG, "Sonarr TVDB lookup failed for '$title'", e)
+            null
+        }
+    }
+
     private suspend fun <T> retryNetworkCall(
         times: Int = 3,
         initialDelay: Long = 500,

--- a/app/src/main/java/com/rpeters/jellyfin/data/repository/SonarrRepository.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/data/repository/SonarrRepository.kt
@@ -218,7 +218,12 @@ class SonarrRepository @Inject constructor(
                 val seriesId = addedBody?.get("id")?.jsonPrimitive?.content?.toIntOrNull()
                     ?: run {
                         SecureLogger.w(TAG, "Could not parse seriesId from addSeries response; refetching by TVDB ID")
-                        service.getSeriesByTvdbId(apiKey, tvdbId).body()?.firstOrNull()?.id
+                        try {
+                            service.getSeriesByTvdbId(apiKey, tvdbId).body()?.firstOrNull()?.id
+                        } catch (e: Exception) {
+                            SecureLogger.w(TAG, "Failed to refetch series by TVDB ID during fallback", e)
+                            null
+                        }
                     }
 
                 if (seriesId != null) {
@@ -312,8 +317,11 @@ class SonarrRepository @Inject constructor(
                 if (id != null) return id
             }
             val results = service.lookupSeriesByTvdb(apiKey, title).body() ?: return null
+            // Prefer an exact title match. Only use the sole result when there's no ambiguity;
+            // with multiple candidates and no exact match we return null rather than risk
+            // requesting the wrong series.
             results.firstOrNull { it.title.equals(title, ignoreCase = true) }?.tvdbId?.takeIf { it != 0 }
-                ?: results.firstOrNull()?.tvdbId?.takeIf { it != 0 }
+                ?: if (results.size == 1) results.first().tvdbId.takeIf { it != 0 } else null
         } catch (e: Exception) {
             SecureLogger.w(TAG, "Sonarr TVDB lookup failed for '$title'", e)
             null

--- a/app/src/main/java/com/rpeters/jellyfin/data/repository/SonarrRepository.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/data/repository/SonarrRepository.kt
@@ -212,8 +212,15 @@ class SonarrRepository @Inject constructor(
 
             val addResponse = service.addSeries(apiKey, addRequest)
             if (addResponse.isSuccessful) {
+                // Sonarr returns the newly created series object; extract the id so we can trigger
+                // an explicit search command. Fall back to a GET if the body can't be parsed.
                 val addedBody = addResponse.body()
-                val seriesId = (addedBody as? JsonObject)?.get("id")?.jsonPrimitive?.content?.toIntOrNull()
+                val seriesId = addedBody?.get("id")?.jsonPrimitive?.content?.toIntOrNull()
+                    ?: run {
+                        SecureLogger.w(TAG, "Could not parse seriesId from addSeries response; refetching by TVDB ID")
+                        service.getSeriesByTvdbId(apiKey, tvdbId).body()?.firstOrNull()?.id
+                    }
+
                 if (seriesId != null) {
                     if (!requestedSeasons.isNullOrEmpty()) {
                         for (season in requestedSeasons) {
@@ -237,6 +244,8 @@ class SonarrRepository @Inject constructor(
                             )
                         )
                     }
+                } else {
+                    SecureLogger.w(TAG, "Series added but could not obtain seriesId to trigger search for TVDB:$tvdbId")
                 }
                 ApiResult.Success(Unit)
             } else {

--- a/app/src/main/java/com/rpeters/jellyfin/ui/viewmodel/RequestsViewModel.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/viewmodel/RequestsViewModel.kt
@@ -608,10 +608,13 @@ class RequestsViewModel @Inject constructor(
         item.tvdbId?.let { return it }
         _uiState.value.tvAvailabilityByMediaId[item.id]?.tvdbId?.let { return it }
         val mediaId = item.tmdbId ?: item.id
-        return when (val result = seerrRepository.getTvDetails(mediaId)) {
+        val seerrId = when (val result = seerrRepository.getTvDetails(mediaId)) {
             is ApiResult.Success -> result.data.externalIds?.tvdbId
             else -> null
         }
+        if (seerrId != null) return seerrId
+        // Seerr unavailable or returned no TVDB ID — ask Sonarr directly via its own lookup.
+        return sonarrRepository.findTvdbId(title = item.displayTitle, tmdbId = item.tmdbId)
     }
 
     fun dismissPendingRequest() {

--- a/app/src/test/java/com/rpeters/jellyfin/ui/viewmodel/RequestsViewModelTest.kt
+++ b/app/src/test/java/com/rpeters/jellyfin/ui/viewmodel/RequestsViewModelTest.kt
@@ -139,6 +139,7 @@ class RequestsViewModelTest {
             name = "Test Show",
         )
         coEvery { seerrRepository.getTvDetails(202) } returns ApiResult.Error("Seerr is not configured")
+        coEvery { sonarrRepository.findTvdbId(any(), any()) } returns null
 
         advanceUntilIdle()
         viewModel.requestSeason(item, 2)
@@ -149,6 +150,28 @@ class RequestsViewModelTest {
             viewModel.uiState.value.errorMessage,
         )
         assertNull(viewModel.uiState.value.successMessage)
+    }
+
+    @Test
+    fun requestSeason_noTvdbIdSeerrFailsSonarrLookupSucceeds_requestsSonarr() = runTest(testDispatcher) {
+        val item = SeerrMediaItem(
+            id = 101,
+            mediaType = "tv",
+            tmdbId = 202,
+            name = "Test Show",
+        )
+        coEvery { seerrRepository.getTvDetails(202) } returns ApiResult.Error("Seerr is not configured")
+        coEvery { sonarrRepository.findTvdbId(any(), any()) } returns 303
+        coEvery { sonarrRepository.addSeries(303, listOf(2)) } returns ApiResult.Success(Unit)
+
+        advanceUntilIdle()
+        viewModel.requestSeason(item, 2)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { sonarrRepository.findTvdbId("Test Show", 202) }
+        coVerify(exactly = 1) { sonarrRepository.addSeries(303, listOf(2)) }
+        assertEquals("Request submitted for Test Show", viewModel.uiState.value.successMessage)
+        assertNull(viewModel.uiState.value.errorMessage)
     }
 
     @Test


### PR DESCRIPTION
## Summary

This PR improves the reliability of adding series to Sonarr by:

1. **Fallback TVDB ID resolution**: When Sonarr's `addSeries` response body cannot be parsed, the code now falls back to fetching the series by TVDB ID instead of silently failing to trigger the search command.

2. **New `findTvdbId()` method**: Adds a public method to `SonarrRepository` that resolves TVDB IDs by trying TMDB ID lookup first (faster), then falling back to title search. This enables the RequestsViewModel to query Sonarr directly when Seerr is unavailable.

3. **Monitoring configuration**: Updates `SonarrAddOptions` to explicitly set `monitor: "all"` by default, ensuring newly added series are properly monitored. Added documentation explaining that without this field, Sonarr defaults to "unknown" and leaves the series unmonitored.

4. **Serialization improvements**: Adds `@EncodeDefault(EncodeDefault.Mode.NEVER)` annotations to optional fields in `SonarrCommand` to prevent sending unnecessary empty arrays/nulls to the API.

5. **Enhanced error logging**: Adds warning logs when series ID cannot be obtained after adding a series, improving debuggability.

## Type of change

- [x] feat (new feature)
- [x] fix (bug fix)

## How to test

```bash
# Build
./gradlew assembleDebug

# Unit tests
./gradlew testDebugUnitTest

# Lint
./gradlew lintDebug
```

## Checklist

- [x] Follows Conventional Commits
- [x] Tests added/updated where applicable
- [x] `./gradlew testDebugUnitTest` passes
- [x] `./gradlew lintDebug` passes

https://claude.ai/code/session_013SxCbbZoSqAiqS2bdNpTd4