### PR TITLE
fix: Improve server URL port detection for reverse proxies

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/utils/ServerUrlValidator.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/utils/ServerUrlValidator.kt
@@ -252,13 +252,17 @@ object ServerUrlValidator {
         }
     }
 
+    // Local-network TLDs commonly used for direct (non-proxied) mDNS/DNS hostnames.
+    private val LOCAL_HOST_SUFFIXES = listOf(".local", ".lan", ".home", ".internal", ".private")
+
     /**
      * Adds default Jellyfin port if no port is specified.
      *
-     * Only guesses a default port for bare IP addresses / localhost, which is how direct,
-     * non-proxied Jellyfin setups are typically reached. Domain names are commonly served
-     * through a reverse proxy on the standard web ports (443/80 - i.e. no explicit port),
-     * so appending :8096/:8920 to them breaks those connections.
+     * Only guesses a default port for hosts that look like a direct, non-proxied connection:
+     * bare IP addresses, localhost, single-label hostnames (e.g. "jellyfin"), and local
+     * network domains (e.g. "jellyfin.local", "nas.lan"). Public-looking domain names are
+     * commonly served through a reverse proxy on the standard web ports (443/80 - i.e. no
+     * explicit port), so appending :8096/:8920 to them breaks those connections.
      */
     private fun addDefaultPortIfMissing(url: String): String {
         return try {
@@ -272,8 +276,10 @@ object ServerUrlValidator {
             val host = uri.host ?: return url
             val path = uri.path ?: ""
 
-            // Only direct IP/localhost connections default to the non-standard Jellyfin ports.
-            val looksLikeDirectConnection = host.equals("localhost", ignoreCase = true) || isValidIPAddress(host)
+            val looksLikeDirectConnection = host.equals("localhost", ignoreCase = true) ||
+                !host.contains(".") ||
+                LOCAL_HOST_SUFFIXES.any { host.endsWith(it, ignoreCase = true) } ||
+                isValidIPAddress(host)
             if (!looksLikeDirectConnection) {
                 return url
             }

--- a/app/src/main/java/com/rpeters/jellyfin/utils/ServerUrlValidator.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/utils/ServerUrlValidator.kt
@@ -254,7 +254,11 @@ object ServerUrlValidator {
 
     /**
      * Adds default Jellyfin port if no port is specified.
-     * For reverse proxy setups (URLs with paths), don't add default ports.
+     *
+     * Only guesses a default port for bare IP addresses / localhost, which is how direct,
+     * non-proxied Jellyfin setups are typically reached. Domain names are commonly served
+     * through a reverse proxy on the standard web ports (443/80 - i.e. no explicit port),
+     * so appending :8096/:8920 to them breaks those connections.
      */
     private fun addDefaultPortIfMissing(url: String): String {
         return try {
@@ -265,12 +269,17 @@ object ServerUrlValidator {
                 return url
             }
 
-            // Check if this looks like a reverse proxy setup
+            val host = uri.host ?: return url
             val path = uri.path ?: ""
-            val isReverseProxy = path.isNotEmpty() && path != "/"
 
-            // For reverse proxy setups, don't add default Jellyfin ports
-            if (isReverseProxy) {
+            // Only direct IP/localhost connections default to the non-standard Jellyfin ports.
+            val looksLikeDirectConnection = host.equals("localhost", ignoreCase = true) || isValidIPAddress(host)
+            if (!looksLikeDirectConnection) {
+                return url
+            }
+
+            // For reverse proxy setups (URLs with paths), don't add default Jellyfin ports
+            if (path.isNotEmpty() && path != "/") {
                 return url
             }
 
@@ -281,7 +290,7 @@ object ServerUrlValidator {
                 else -> DEFAULT_HTTP_PORT
             }
 
-            "${uri.scheme}://${uri.host}:$defaultPort${uri.path ?: ""}"
+            "${uri.scheme}://$host:$defaultPort$path"
         } catch (e: URISyntaxException) {
             Log.w(TAG, "Failed to parse URI for port addition: $url", e)
             url


### PR DESCRIPTION
## Summary

Refines the logic for adding default Jellyfin ports (8096/8920) to server URLs. The previous implementation only checked for the presence of a path to detect reverse proxy setups, which could incorrectly add non-standard ports to domain-based URLs served through reverse proxies on standard web ports (80/443).

This change now only adds default Jellyfin ports for direct IP addresses and localhost connections, which is how non-proxied Jellyfin setups are typically reached. Domain names are commonly served through reverse proxies on standard web ports, so appending explicit ports breaks those connections.

**Key improvements:**
- Added `isValidIPAddress()` check to distinguish direct IP connections from domain-based URLs
- Reordered logic to check for direct connections first, before checking for reverse proxy paths
- Improved code clarity with better variable naming and comments
- Simplified URI component access with null coalescing

## Type of change

- [x] fix (bug fix)
- [x] refactor (no functional change)

## How to test

```bash
# Unit tests
./gradlew testDebugUnitTest

# Lint
./gradlew lintDebug
```

## Checklist

- [x] Follows Conventional Commits
- [x] Tests added/updated where applicable
- [x] `./gradlew testDebugUnitTest` passes
- [x] `./gradlew lintDebug` passes

https://claude.ai/code/session_01MHCvWx8VmmARaaMug9pxV5