### PR TITLE
feat: Add custom accent color picker with HSV/hex input

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -197,6 +197,7 @@ dependencies {
     implementation(libs.androidx.material3.window.size)
     implementation(libs.androidx.window)
     implementation(libs.google.material)
+    implementation(libs.material.kolor)
 
     // Navigation
     implementation(libs.androidx.navigation.compose)

--- a/app/src/main/java/com/rpeters/jellyfin/data/preferences/ThemePreferences.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/data/preferences/ThemePreferences.kt
@@ -35,6 +35,9 @@ enum class ContrastLevel {
  * Custom accent color options when dynamic color is disabled.
  */
 enum class AccentColor {
+    /** Matches the actual jellyfin-web client palette (accent blue, near-black surfaces) */
+    JELLYFIN_CLASSIC,
+
     /** Default Jellyfin purple */
     JELLYFIN_PURPLE,
 

--- a/app/src/main/java/com/rpeters/jellyfin/data/preferences/ThemePreferences.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/data/preferences/ThemePreferences.kt
@@ -58,6 +58,9 @@ enum class AccentColor {
 
     /** Material orange */
     MATERIAL_ORANGE,
+
+    /** User-picked custom seed color (see [ThemePreferences.customAccentColorArgb]) */
+    CUSTOM,
 }
 
 /**
@@ -98,6 +101,12 @@ data class ThemePreferences(
     val accentColor: AccentColor = AccentColor.JELLYFIN_PURPLE,
 
     /**
+     * ARGB value of the user-picked seed color, used when [accentColor] is [AccentColor.CUSTOM].
+     * Defaults to the Jellyfin expressive primary purple.
+     */
+    val customAccentColorArgb: Int = DEFAULT_CUSTOM_ACCENT_ARGB,
+
+    /**
      * Contrast level for theme colors.
      */
     val contrastLevel: ContrastLevel = ContrastLevel.STANDARD,
@@ -130,3 +139,6 @@ data class ThemePreferences(
         val DEFAULT = ThemePreferences()
     }
 }
+
+/** ARGB for [ThemePreferences.customAccentColorArgb]'s default; matches ui.theme.ExpressivePrimary. */
+const val DEFAULT_CUSTOM_ACCENT_ARGB: Int = 0xFF6442D6.toInt()

--- a/app/src/main/java/com/rpeters/jellyfin/data/preferences/ThemePreferencesRepository.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/data/preferences/ThemePreferencesRepository.kt
@@ -110,11 +110,15 @@ open class ThemePreferencesRepository(
     }
 
     /**
-     * Update the user-picked custom seed color (ARGB), used when accent color is [AccentColor.CUSTOM].
+     * Update the user-picked custom seed color (ARGB) in a single DataStore write, optionally
+     * also selecting it as the active accent color to avoid a second write + flow emission.
      */
-    open suspend fun setCustomAccentColorArgb(argb: Int) {
+    open suspend fun setCustomAccentColor(argb: Int, selectAsActive: Boolean = true) {
         dataStore.edit { preferences ->
             preferences[PreferencesKeys.CUSTOM_ACCENT_COLOR] = argb
+            if (selectAsActive) {
+                preferences[PreferencesKeys.ACCENT_COLOR] = AccentColor.CUSTOM.name
+            }
         }
     }
 

--- a/app/src/main/java/com/rpeters/jellyfin/data/preferences/ThemePreferencesRepository.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/data/preferences/ThemePreferencesRepository.kt
@@ -5,6 +5,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.rpeters.jellyfin.utils.SecureLogger
@@ -62,6 +63,8 @@ open class ThemePreferencesRepository(
                     value = preferences[PreferencesKeys.ACCENT_COLOR],
                     default = defaults.accentColor,
                 ),
+                customAccentColorArgb = preferences[PreferencesKeys.CUSTOM_ACCENT_COLOR]
+                    ?: defaults.customAccentColorArgb,
                 contrastLevel = parseEnum(
                     value = preferences[PreferencesKeys.CONTRAST_LEVEL],
                     default = defaults.contrastLevel,
@@ -103,6 +106,15 @@ open class ThemePreferencesRepository(
     open suspend fun setAccentColor(accentColor: AccentColor) {
         dataStore.edit { preferences ->
             preferences[PreferencesKeys.ACCENT_COLOR] = accentColor.name
+        }
+    }
+
+    /**
+     * Update the user-picked custom seed color (ARGB), used when accent color is [AccentColor.CUSTOM].
+     */
+    open suspend fun setCustomAccentColorArgb(argb: Int) {
+        dataStore.edit { preferences ->
+            preferences[PreferencesKeys.CUSTOM_ACCENT_COLOR] = argb
         }
     }
 
@@ -191,6 +203,7 @@ open class ThemePreferencesRepository(
         val THEME_MODE = stringPreferencesKey("theme_mode")
         val USE_DYNAMIC_COLORS = booleanPreferencesKey("use_dynamic_colors")
         val ACCENT_COLOR = stringPreferencesKey("accent_color")
+        val CUSTOM_ACCENT_COLOR = intPreferencesKey("custom_accent_color_argb")
         val CONTRAST_LEVEL = stringPreferencesKey("contrast_level")
         val APP_FONT = stringPreferencesKey("app_font")
         val USE_THEMED_ICON = booleanPreferencesKey("use_themed_icon")

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/settings/AppearanceSettingsScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/settings/AppearanceSettingsScreen.kt
@@ -29,12 +29,14 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Accessibility
 import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.ColorLens
+import androidx.compose.material.icons.filled.Colorize
 import androidx.compose.material.icons.filled.Contrast
 import androidx.compose.material.icons.filled.DarkMode
 import androidx.compose.material.icons.filled.FontDownload
@@ -43,22 +45,32 @@ import androidx.compose.material.icons.filled.Palette
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Tonality
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
@@ -100,6 +112,18 @@ fun AppearanceSettingsScreen(
     viewModel: ThemePreferencesViewModel = hiltViewModel(),
 ) {
     val themePreferences by viewModel.themePreferences.collectAsStateWithLifecycle()
+    var showCustomColorPicker by remember { mutableStateOf(false) }
+
+    if (showCustomColorPicker) {
+        CustomColorPickerDialog(
+            initialColor = Color(themePreferences.customAccentColorArgb),
+            onDismiss = { showCustomColorPicker = false },
+            onConfirm = { color ->
+                viewModel.setCustomAccentColor(color.toArgb())
+                showCustomColorPicker = false
+            },
+        )
+    }
 
     Scaffold(
         topBar = {
@@ -176,7 +200,9 @@ fun AppearanceSettingsScreen(
                             )
                             AccentColorRow(
                                 selectedColor = themePreferences.accentColor,
-                                onColorSelect = { viewModel.setAccentColor(it) }
+                                customColor = Color(themePreferences.customAccentColorArgb),
+                                onColorSelect = { viewModel.setAccentColor(it) },
+                                onCustomColorClick = { showCustomColorPicker = true },
                             )
                         }
                     }
@@ -204,7 +230,9 @@ fun AppearanceSettingsScreen(
                     )
                     AccentColorRow(
                         selectedColor = themePreferences.accentColor,
-                        onColorSelect = { viewModel.setAccentColor(it) }
+                        customColor = Color(themePreferences.customAccentColorArgb),
+                        onColorSelect = { viewModel.setAccentColor(it) },
+                        onCustomColorClick = { showCustomColorPicker = true },
                     )
                 }
             }
@@ -567,20 +595,172 @@ private fun ThemeModeCard(
 @Composable
 private fun AccentColorRow(
     selectedColor: AccentColor,
-    onColorSelect: (AccentColor) -> Unit
+    customColor: Color,
+    onColorSelect: (AccentColor) -> Unit,
+    onCustomColorClick: () -> Unit,
 ) {
     LazyRow(
         horizontalArrangement = Arrangement.spacedBy(16.dp),
         contentPadding = PaddingValues(horizontal = 4.dp, vertical = 8.dp)
     ) {
-        items(AccentColor.entries) { color ->
+        items(AccentColor.entries.filter { it != AccentColor.CUSTOM }) { color ->
             AccentColorCircle(
                 color = color,
                 selected = selectedColor == color,
                 onClick = { onColorSelect(color) }
             )
         }
+        item {
+            CustomAccentColorCircle(
+                customColor = customColor,
+                selected = selectedColor == AccentColor.CUSTOM,
+                onClick = onCustomColorClick,
+            )
+        }
     }
+}
+
+@Composable
+private fun CustomAccentColorCircle(
+    customColor: Color,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    val size by animateDpAsState(targetValue = if (selected) 56.dp else 48.dp, label = "size")
+    val borderColor by animateColorAsState(
+        targetValue = if (selected) JellyfinExpressiveTheme.colors.selectionOutline else Color.Transparent,
+        label = "border"
+    )
+    val rainbowBrush = remember {
+        Brush.sweepGradient(
+            listOf(
+                Color(0xFFFF0000),
+                Color(0xFFFFFF00),
+                Color(0xFF00FF00),
+                Color(0xFF00FFFF),
+                Color(0xFF0000FF),
+                Color(0xFFFF00FF),
+                Color(0xFFFF0000),
+            )
+        )
+    }
+
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+        modifier = Modifier.width(64.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .size(size)
+                .shadow(if (selected) 8.dp else 2.dp, CircleShape)
+                .clip(CircleShape)
+                .then(
+                    if (selected) Modifier.background(customColor)
+                    else Modifier.background(rainbowBrush)
+                )
+                .then(
+                    if (selected) Modifier.border(3.dp, borderColor, CircleShape)
+                    else Modifier
+                )
+                .clickable(onClick = onClick),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = if (selected) Icons.Default.Check else Icons.Default.Colorize,
+                contentDescription = "Pick a custom accent color",
+                tint = if (selected && customColor.luminance() > 0.5f) Color.Black else Color.White,
+                modifier = Modifier.size(if (selected) 24.dp else 20.dp)
+            )
+        }
+        Text(
+            text = "Custom",
+            style = MaterialTheme.typography.labelSmall,
+            color = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+            fontWeight = if (selected) FontWeight.Bold else FontWeight.Normal,
+            maxLines = 1
+        )
+    }
+}
+
+@Composable
+private fun CustomColorPickerDialog(
+    initialColor: Color,
+    onDismiss: () -> Unit,
+    onConfirm: (Color) -> Unit,
+) {
+    val initialHsv = remember(initialColor) {
+        val hsv = FloatArray(3)
+        android.graphics.Color.colorToHSV(initialColor.toArgb(), hsv)
+        hsv
+    }
+    var hue by remember { mutableFloatStateOf(initialHsv[0]) }
+    var saturation by remember { mutableFloatStateOf(initialHsv[1]) }
+    var brightness by remember { mutableFloatStateOf(initialHsv[2]) }
+    val previewColor = Color(android.graphics.Color.HSVToColor(floatArrayOf(hue, saturation, brightness)))
+    var hexText by remember(previewColor) {
+        mutableStateOf(
+            "#%06X".format(java.util.Locale.ROOT, 0xFFFFFF and previewColor.toArgb()),
+        )
+    }
+
+    fun applyHex(text: String) {
+        hexText = text
+        val normalized = if (text.startsWith("#")) text else "#$text"
+        val parsedArgb = runCatching { android.graphics.Color.parseColor(normalized) }.getOrNull()
+        if (parsedArgb != null) {
+            val hsv = FloatArray(3)
+            android.graphics.Color.colorToHSV(parsedArgb, hsv)
+            hue = hsv[0]
+            saturation = hsv[1]
+            brightness = hsv[2]
+        }
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Custom Accent Color") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(64.dp)
+                        .clip(RoundedCornerShape(16.dp))
+                        .background(previewColor)
+                )
+                Column {
+                    Text("Hue", style = MaterialTheme.typography.labelMedium)
+                    Slider(value = hue, onValueChange = { hue = it }, valueRange = 0f..360f)
+                }
+                Column {
+                    Text("Saturation", style = MaterialTheme.typography.labelMedium)
+                    Slider(value = saturation, onValueChange = { saturation = it }, valueRange = 0f..1f)
+                }
+                Column {
+                    Text("Brightness", style = MaterialTheme.typography.labelMedium)
+                    Slider(value = brightness, onValueChange = { brightness = it }, valueRange = 0.05f..1f)
+                }
+                OutlinedTextField(
+                    value = hexText,
+                    onValueChange = { applyHex(it) },
+                    label = { Text("Hex") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onConfirm(previewColor) }) {
+                Text("Apply")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel")
+            }
+        },
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/settings/AppearanceSettingsScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/settings/AppearanceSettingsScreen.kt
@@ -58,6 +58,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -592,6 +593,8 @@ private fun ThemeModeCard(
     }
 }
 
+private val PresetAccentColors = AccentColor.entries.filter { it != AccentColor.CUSTOM }
+
 @Composable
 private fun AccentColorRow(
     selectedColor: AccentColor,
@@ -603,7 +606,7 @@ private fun AccentColorRow(
         horizontalArrangement = Arrangement.spacedBy(16.dp),
         contentPadding = PaddingValues(horizontal = 4.dp, vertical = 8.dp)
     ) {
-        items(AccentColor.entries.filter { it != AccentColor.CUSTOM }) { color ->
+        items(PresetAccentColors) { color ->
             AccentColorCircle(
                 color = color,
                 selected = selectedColor == color,
@@ -694,14 +697,29 @@ private fun CustomColorPickerDialog(
         android.graphics.Color.colorToHSV(initialColor.toArgb(), hsv)
         hsv
     }
-    var hue by remember { mutableFloatStateOf(initialHsv[0]) }
-    var saturation by remember { mutableFloatStateOf(initialHsv[1]) }
-    var brightness by remember { mutableFloatStateOf(initialHsv[2]) }
-    val previewColor = Color(android.graphics.Color.HSVToColor(floatArrayOf(hue, saturation, brightness)))
-    var hexText by remember(previewColor) {
+    var hue by remember(initialHsv) { mutableFloatStateOf(initialHsv[0]) }
+    var saturation by remember(initialHsv) { mutableFloatStateOf(initialHsv[1]) }
+    var brightness by remember(initialHsv) { mutableFloatStateOf(initialHsv[2]) }
+    val hsvArray = remember { FloatArray(3) }
+    hsvArray[0] = hue
+    hsvArray[1] = saturation
+    hsvArray[2] = brightness
+    val previewColor = Color(android.graphics.Color.HSVToColor(hsvArray))
+    var hexText by remember(initialColor) {
         mutableStateOf(
-            "#%06X".format(java.util.Locale.ROOT, 0xFFFFFF and previewColor.toArgb()),
+            "#%06X".format(java.util.Locale.ROOT, 0xFFFFFF and initialColor.toArgb()),
         )
+    }
+
+    // Reflect slider-driven color changes into the hex field, but only when the
+    // parsed hex doesn't already match — otherwise typing a valid hex would
+    // recompose this state and jump the cursor to the end on every keystroke.
+    LaunchedEffect(previewColor) {
+        val normalized = if (hexText.startsWith("#")) hexText else "#$hexText"
+        val parsedArgb = runCatching { android.graphics.Color.parseColor(normalized) }.getOrNull()
+        if (parsedArgb != previewColor.toArgb()) {
+            hexText = "#%06X".format(java.util.Locale.ROOT, 0xFFFFFF and previewColor.toArgb())
+        }
     }
 
     fun applyHex(text: String) {

--- a/app/src/main/java/com/rpeters/jellyfin/ui/theme/Color.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/theme/Color.kt
@@ -86,6 +86,39 @@ val SubtitlePreviewGradientStart = Color(0xFF1A1A1A)
 val SubtitlePreviewGradientEnd = Color(0xFF333333)
 
 // ============================================================================
+// JELLYFIN CLASSIC (WEB CLIENT) PALETTE
+// ============================================================================
+// Sourced directly from jellyfin-web's shipped theme so this preset matches
+// the actual server web UI, not a Material reinterpretation of the brand.
+// See: jellyfin/jellyfin-web src/themes/_base/_palette.scss, dark/theme.scss,
+// light/theme.scss.
+
+// Accent (MUI primary) — identical across light and dark in jellyfin-web
+val JellyfinClassicPrimary = Color(0xFF00A4DC)
+val JellyfinClassicPrimaryDark = Color(0xFF00729A)
+val JellyfinClassicPrimaryLight = Color(0xFF33B6E3)
+val JellyfinClassicOnPrimary = Color(0xFF0D1B1F) // MUI primary-contrastText: rgba(0,0,0,.87)
+
+// Error (MUI error palette)
+val JellyfinClassicError = Color(0xFFC62828)
+val JellyfinClassicErrorDark = Color(0xFF8A1C1C)
+val JellyfinClassicErrorLight = Color(0xFFD15353)
+
+// Dark theme surfaces (jellyfin-web default theme)
+val JellyfinClassicDarkBackground = Color(0xFF101010)
+val JellyfinClassicDarkPaper = Color(0xFF202020)
+val JellyfinClassicDarkOnSurfaceVariant = Color(0xFFB7B7B7) // text-secondary ~70% white
+val JellyfinClassicDarkOutline = Color(0xFF6B6B6B)
+val JellyfinClassicDarkOutlineVariant = Color(0xFF3B3B3B) // divider ~12% white
+
+// Light theme surfaces (jellyfin-web light theme)
+val JellyfinClassicLightBackground = Color(0xFFF2F2F2)
+val JellyfinClassicLightPaper = Color(0xFFE8E8E8)
+val JellyfinClassicLightOnSurfaceVariant = Color(0xFF5C5C5C)
+val JellyfinClassicLightOutline = Color(0xFF8A8A8A)
+val JellyfinClassicLightOutlineVariant = Color(0xFFC8C8C8)
+
+// ============================================================================
 // EXPRESSIVE COLOR SYSTEM
 // ============================================================================
 

--- a/app/src/main/java/com/rpeters/jellyfin/ui/theme/ColorSchemes.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/theme/ColorSchemes.kt
@@ -10,6 +10,7 @@ import com.rpeters.jellyfin.data.preferences.AccentColor
  */
 fun getLightColorScheme(accentColor: AccentColor): androidx.compose.material3.ColorScheme {
     return when (accentColor) {
+        AccentColor.JELLYFIN_CLASSIC -> JellyfinClassicLightColorScheme
         AccentColor.JELLYFIN_PURPLE -> JellyfinPurpleLightColorScheme
         AccentColor.JELLYFIN_BLUE -> JellyfinBlueLightColorScheme
         AccentColor.JELLYFIN_TEAL -> JellyfinTealLightColorScheme
@@ -30,6 +31,7 @@ fun getLightColorScheme(accentColor: AccentColor): androidx.compose.material3.Co
  */
 fun getDarkColorScheme(accentColor: AccentColor): androidx.compose.material3.ColorScheme {
     return when (accentColor) {
+        AccentColor.JELLYFIN_CLASSIC -> JellyfinClassicDarkColorScheme
         AccentColor.JELLYFIN_PURPLE -> JellyfinPurpleDarkColorScheme
         AccentColor.JELLYFIN_BLUE -> JellyfinBlueDarkColorScheme
         AccentColor.JELLYFIN_TEAL -> JellyfinTealDarkColorScheme
@@ -48,6 +50,7 @@ fun getDarkColorScheme(accentColor: AccentColor): androidx.compose.material3.Col
  */
 fun getAmoledBlackColorScheme(accentColor: AccentColor): androidx.compose.material3.ColorScheme {
     return when (accentColor) {
+        AccentColor.JELLYFIN_CLASSIC -> JellyfinClassicAmoledColorScheme
         AccentColor.JELLYFIN_PURPLE -> JellyfinPurpleAmoledColorScheme
         AccentColor.JELLYFIN_BLUE -> JellyfinBlueAmoledColorScheme
         AccentColor.JELLYFIN_TEAL -> JellyfinTealAmoledColorScheme
@@ -59,6 +62,95 @@ fun getAmoledBlackColorScheme(accentColor: AccentColor): androidx.compose.materi
         AccentColor.CUSTOM -> JellyfinPurpleAmoledColorScheme
     }
 }
+
+// ============================================================================
+// JELLYFIN CLASSIC COLOR SCHEMES
+// ============================================================================
+// Reproduces jellyfin-web's actual shipped palette as closely as Material 3's
+// tonal-role system allows. Secondary/tertiary have no direct MUI equivalent
+// (jellyfin-web is effectively single-accent + grayscale), so they're muted,
+// low-saturation companions to the real accent rather than invented brand hues.
+
+private val JellyfinClassicLightColorScheme = lightColorScheme(
+    primary = JellyfinClassicPrimary,
+    onPrimary = JellyfinClassicOnPrimary,
+    primaryContainer = Color(0xFFB3E5FC),
+    onPrimaryContainer = Color(0xFF00323F),
+    secondary = Color(0xFF4A6572),
+    onSecondary = Color.White,
+    secondaryContainer = Color(0xFFCFE8F3),
+    onSecondaryContainer = Color(0xFF0A1F26),
+    tertiary = Color(0xFF8A6D1A),
+    onTertiary = Color.White,
+    tertiaryContainer = Color(0xFFF2DFA6),
+    onTertiaryContainer = Color(0xFF2B2205),
+    error = JellyfinClassicError,
+    onError = Color.White,
+    errorContainer = Color(0xFFFFDAD6),
+    onErrorContainer = JellyfinClassicErrorDark,
+    background = JellyfinClassicLightBackground,
+    onBackground = Color.Black,
+    surface = JellyfinClassicLightBackground,
+    onSurface = Color.Black,
+    surfaceVariant = JellyfinClassicLightPaper,
+    onSurfaceVariant = JellyfinClassicLightOnSurfaceVariant,
+    outline = JellyfinClassicLightOutline,
+    outlineVariant = JellyfinClassicLightOutlineVariant,
+)
+
+private val JellyfinClassicDarkColorScheme = darkColorScheme(
+    primary = JellyfinClassicPrimary,
+    onPrimary = JellyfinClassicOnPrimary,
+    primaryContainer = Color(0xFF00506B),
+    onPrimaryContainer = Color(0xFFB3E5FC),
+    secondary = Color(0xFF8FA6B3),
+    onSecondary = Color(0xFF16232A),
+    secondaryContainer = Color(0xFF2E4552),
+    onSecondaryContainer = Color(0xFFCBE0EC),
+    tertiary = Color(0xFFD4AF37),
+    onTertiary = Color(0xFF2B2205),
+    tertiaryContainer = Color(0xFF4A3B0A),
+    onTertiaryContainer = Color(0xFFF2DFA6),
+    error = JellyfinClassicError,
+    onError = Color.White,
+    errorContainer = JellyfinClassicErrorDark,
+    onErrorContainer = Color(0xFFFFDAD6),
+    background = JellyfinClassicDarkBackground,
+    onBackground = Color.White,
+    surface = JellyfinClassicDarkBackground,
+    onSurface = Color.White,
+    surfaceVariant = JellyfinClassicDarkPaper,
+    onSurfaceVariant = JellyfinClassicDarkOnSurfaceVariant,
+    outline = JellyfinClassicDarkOutline,
+    outlineVariant = JellyfinClassicDarkOutlineVariant,
+)
+
+private val JellyfinClassicAmoledColorScheme = darkColorScheme(
+    primary = JellyfinClassicPrimary,
+    onPrimary = JellyfinClassicOnPrimary,
+    primaryContainer = Color(0xFF00506B),
+    onPrimaryContainer = Color(0xFFB3E5FC),
+    secondary = Color(0xFF8FA6B3),
+    onSecondary = Color(0xFF16232A),
+    secondaryContainer = Color(0xFF1E2D34),
+    onSecondaryContainer = Color(0xFFCBE0EC),
+    tertiary = Color(0xFFD4AF37),
+    onTertiary = Color(0xFF2B2205),
+    tertiaryContainer = Color(0xFF332800),
+    onTertiaryContainer = Color(0xFFF2DFA6),
+    error = JellyfinClassicError,
+    onError = Color.White,
+    errorContainer = JellyfinClassicErrorDark,
+    onErrorContainer = Color(0xFFFFDAD6),
+    background = Color.Black,
+    onBackground = Color.White,
+    surface = Color.Black,
+    onSurface = Color.White,
+    surfaceVariant = Color(0xFF1A1A1A),
+    onSurfaceVariant = JellyfinClassicDarkOnSurfaceVariant,
+    outline = JellyfinClassicDarkOutline,
+    outlineVariant = Color(0xFF2A2A2A),
+)
 
 // ============================================================================
 // JELLYFIN PURPLE COLOR SCHEMES

--- a/app/src/main/java/com/rpeters/jellyfin/ui/theme/ColorSchemes.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/theme/ColorSchemes.kt
@@ -18,6 +18,9 @@ fun getLightColorScheme(accentColor: AccentColor): androidx.compose.material3.Co
         AccentColor.MATERIAL_GREEN -> MaterialGreenLightColorScheme
         AccentColor.MATERIAL_RED -> MaterialRedLightColorScheme
         AccentColor.MATERIAL_ORANGE -> MaterialOrangeLightColorScheme
+        // CUSTOM is handled upstream in JellyfinAndroidTheme via rememberDynamicColorScheme;
+        // this fallback only matters if this function is called directly with CUSTOM.
+        AccentColor.CUSTOM -> JellyfinPurpleLightColorScheme
     }
 }
 
@@ -35,6 +38,7 @@ fun getDarkColorScheme(accentColor: AccentColor): androidx.compose.material3.Col
         AccentColor.MATERIAL_GREEN -> MaterialGreenDarkColorScheme
         AccentColor.MATERIAL_RED -> MaterialRedDarkColorScheme
         AccentColor.MATERIAL_ORANGE -> MaterialOrangeDarkColorScheme
+        AccentColor.CUSTOM -> JellyfinPurpleDarkColorScheme
     }
 }
 
@@ -52,6 +56,7 @@ fun getAmoledBlackColorScheme(accentColor: AccentColor): androidx.compose.materi
         AccentColor.MATERIAL_GREEN -> MaterialGreenAmoledColorScheme
         AccentColor.MATERIAL_RED -> MaterialRedAmoledColorScheme
         AccentColor.MATERIAL_ORANGE -> MaterialOrangeAmoledColorScheme
+        AccentColor.CUSTOM -> JellyfinPurpleAmoledColorScheme
     }
 }
 

--- a/app/src/main/java/com/rpeters/jellyfin/ui/theme/Theme.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/theme/Theme.kt
@@ -5,12 +5,16 @@ package com.rpeters.jellyfin.ui.theme
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.ColorScheme
-import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MaterialExpressiveTheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import com.materialkolor.PaletteStyle
+import com.materialkolor.rememberDynamicColorScheme
 import com.rpeters.jellyfin.OptInAppExperimentalApis
+import com.rpeters.jellyfin.data.preferences.AccentColor
 import com.rpeters.jellyfin.data.preferences.ContrastLevel
 import com.rpeters.jellyfin.data.preferences.ThemeMode
 import com.rpeters.jellyfin.data.preferences.ThemePreferences
@@ -81,6 +85,17 @@ fun JellyfinAndroidTheme(
             }
         }
 
+        // User-picked custom seed color: generate a full Material You palette from it,
+        // using the Expressive palette style for richer, more distinct tonal roles.
+        themePreferences.accentColor == AccentColor.CUSTOM -> {
+            rememberDynamicColorScheme(
+                seedColor = Color(themePreferences.customAccentColorArgb),
+                isDark = darkTheme,
+                isAmoled = themePreferences.themeMode == ThemeMode.AMOLED_BLACK,
+                style = PaletteStyle.Expressive,
+            )
+        }
+
         // Use AMOLED Black theme
         themePreferences.themeMode == ThemeMode.AMOLED_BLACK -> {
             getAmoledBlackColorScheme(themePreferences.accentColor)
@@ -107,7 +122,7 @@ fun JellyfinAndroidTheme(
 
     val fontFamily = themePreferences.appFont.toFontFamily()
 
-    MaterialTheme(
+    MaterialExpressiveTheme(
         colorScheme = tunedColorScheme,
         typography = getTypography(fontFamily),
         shapes = JellyfinShapes,

--- a/app/src/main/java/com/rpeters/jellyfin/ui/theme/ThemeUtils.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/theme/ThemeUtils.kt
@@ -9,7 +9,7 @@ import com.rpeters.jellyfin.data.preferences.ThemeMode
  * Get a preview color for an accent color selection.
  * Used in the accent color picker to show what each color looks like.
  */
-fun getAccentColorForPreview(accentColor: AccentColor): Color {
+fun getAccentColorForPreview(accentColor: AccentColor, customColor: Color = Color(0xFF6442D6)): Color {
     return when (accentColor) {
         AccentColor.JELLYFIN_PURPLE -> JellyfinPurple40
         AccentColor.JELLYFIN_BLUE -> JellyfinBlue40
@@ -19,6 +19,7 @@ fun getAccentColorForPreview(accentColor: AccentColor): Color {
         AccentColor.MATERIAL_GREEN -> Color(0xFF006E1C)
         AccentColor.MATERIAL_RED -> Color(0xFFB3261E)
         AccentColor.MATERIAL_ORANGE -> Color(0xFF825500)
+        AccentColor.CUSTOM -> customColor
     }
 }
 
@@ -81,5 +82,6 @@ fun getAccentColorName(accentColor: AccentColor): String {
         AccentColor.MATERIAL_GREEN -> "Material Green"
         AccentColor.MATERIAL_RED -> "Material Red"
         AccentColor.MATERIAL_ORANGE -> "Material Orange"
+        AccentColor.CUSTOM -> "Custom"
     }
 }

--- a/app/src/main/java/com/rpeters/jellyfin/ui/theme/ThemeUtils.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/theme/ThemeUtils.kt
@@ -9,7 +9,7 @@ import com.rpeters.jellyfin.data.preferences.ThemeMode
  * Get a preview color for an accent color selection.
  * Used in the accent color picker to show what each color looks like.
  */
-fun getAccentColorForPreview(accentColor: AccentColor, customColor: Color = Color(0xFF6442D6)): Color {
+fun getAccentColorForPreview(accentColor: AccentColor, customColor: Color = ExpressivePrimary): Color {
     return when (accentColor) {
         AccentColor.JELLYFIN_CLASSIC -> JellyfinClassicPrimary
         AccentColor.JELLYFIN_PURPLE -> JellyfinPurple40

--- a/app/src/main/java/com/rpeters/jellyfin/ui/theme/ThemeUtils.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/theme/ThemeUtils.kt
@@ -11,6 +11,7 @@ import com.rpeters.jellyfin.data.preferences.ThemeMode
  */
 fun getAccentColorForPreview(accentColor: AccentColor, customColor: Color = Color(0xFF6442D6)): Color {
     return when (accentColor) {
+        AccentColor.JELLYFIN_CLASSIC -> JellyfinClassicPrimary
         AccentColor.JELLYFIN_PURPLE -> JellyfinPurple40
         AccentColor.JELLYFIN_BLUE -> JellyfinBlue40
         AccentColor.JELLYFIN_TEAL -> JellyfinTeal40
@@ -74,6 +75,7 @@ fun getContrastLevelDescription(contrastLevel: ContrastLevel): String {
  */
 fun getAccentColorName(accentColor: AccentColor): String {
     return when (accentColor) {
+        AccentColor.JELLYFIN_CLASSIC -> "Jellyfin Classic"
         AccentColor.JELLYFIN_PURPLE -> "Jellyfin Purple"
         AccentColor.JELLYFIN_BLUE -> "Jellyfin Blue"
         AccentColor.JELLYFIN_TEAL -> "Jellyfin Teal"

--- a/app/src/main/java/com/rpeters/jellyfin/ui/viewmodel/ThemePreferencesViewModel.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/viewmodel/ThemePreferencesViewModel.kt
@@ -96,8 +96,7 @@ class ThemePreferencesViewModel @Inject constructor(
     fun setCustomAccentColor(argb: Int) {
         viewModelScope.launch {
             try {
-                themePreferencesRepository.setCustomAccentColorArgb(argb)
-                themePreferencesRepository.setAccentColor(AccentColor.CUSTOM)
+                themePreferencesRepository.setCustomAccentColor(argb, selectAsActive = true)
                 SecureLogger.d(TAG, "Custom accent color updated")
             } catch (e: CancellationException) {
                 throw e

--- a/app/src/main/java/com/rpeters/jellyfin/ui/viewmodel/ThemePreferencesViewModel.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/viewmodel/ThemePreferencesViewModel.kt
@@ -91,6 +91,23 @@ class ThemePreferencesViewModel @Inject constructor(
     }
 
     /**
+     * Update the user-picked custom seed color (ARGB), also switching accent color to CUSTOM.
+     */
+    fun setCustomAccentColor(argb: Int) {
+        viewModelScope.launch {
+            try {
+                themePreferencesRepository.setCustomAccentColorArgb(argb)
+                themePreferencesRepository.setAccentColor(AccentColor.CUSTOM)
+                SecureLogger.d(TAG, "Custom accent color updated")
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                SecureLogger.e(TAG, "Failed to update custom accent color", e)
+            }
+        }
+    }
+
+    /**
      * Update the contrast level.
      */
     fun setContrastLevel(contrastLevel: ContrastLevel) {

--- a/app/src/test/java/com/rpeters/jellyfin/data/preferences/ThemePreferencesRepositoryTest.kt
+++ b/app/src/test/java/com/rpeters/jellyfin/data/preferences/ThemePreferencesRepositoryTest.kt
@@ -108,6 +108,30 @@ class ThemePreferencesRepositoryTest {
     }
 
     @Test
+    fun `setCustomAccentColor persists argb and selects CUSTOM in a single write`() = runTest {
+        val repository = createRepository()
+        val argb = 0xFF33B6E3.toInt()
+
+        repository.setCustomAccentColor(argb)
+        val preferences = repository.themePreferencesFlow.first()
+
+        assertEquals(argb, preferences.customAccentColorArgb)
+        assertEquals(AccentColor.CUSTOM, preferences.accentColor)
+    }
+
+    @Test
+    fun `setCustomAccentColor with selectAsActive false only persists argb`() = runTest {
+        val repository = createRepository()
+        val argb = 0xFF33B6E3.toInt()
+
+        repository.setCustomAccentColor(argb, selectAsActive = false)
+        val preferences = repository.themePreferencesFlow.first()
+
+        assertEquals(argb, preferences.customAccentColorArgb)
+        assertEquals(AccentColor.JELLYFIN_PURPLE, preferences.accentColor)
+    }
+
+    @Test
     fun `setAccentColor persists all available colors`() = runTest {
         val repository = createRepository()
         AccentColor.entries.forEach { color ->

--- a/app/src/test/java/com/rpeters/jellyfin/ui/viewmodel/ThemePreferencesViewModelTest.kt
+++ b/app/src/test/java/com/rpeters/jellyfin/ui/viewmodel/ThemePreferencesViewModelTest.kt
@@ -225,6 +225,20 @@ class ThemePreferencesViewModelTest {
         }
     }
 
+    @Test
+    fun `setCustomAccentColor calls repository with argb and selectAsActive true`() = runTest {
+        // Given
+        val argb = 0xFF33B6E3.toInt()
+        coEvery { mockRepository.setCustomAccentColor(any(), any()) } returns Unit
+
+        // When
+        viewModel.setCustomAccentColor(argb)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Then
+        coVerify(exactly = 1) { mockRepository.setCustomAccentColor(argb, selectAsActive = true) }
+    }
+
     // ========================================================================
     // CONTRAST LEVEL TESTS
     // ========================================================================

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -66,9 +66,11 @@ googleFirebasePerf = "2.0.2"
 glance = "1.3.0-alpha02"
 mlkitGenaiPrompt = "1.0.0-beta2"
 orbit = "11.0.0"
+materialKolor = "4.1.1"
 
 [libraries]
 androidx-compose-ui-test = { module = "androidx.compose.ui:ui-test" }
+material-kolor = { group = "com.materialkolor", name = "material-kolor", version.ref = "materialKolor" }
 glance-appwidget = { group = "androidx.glance", name = "glance-appwidget", version.ref = "glance" }
 glance-material3 = { group = "androidx.glance", name = "glance-material3", version.ref = "glance" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }


### PR DESCRIPTION
## Summary

Adds a user-facing custom accent color picker to the appearance settings, allowing users to select any color as their app accent instead of being limited to preset options. The custom color is stored as an ARGB integer and generates a full Material You palette using the Expressive style via the MaterialKolor library.

Key additions:
- **CustomColorPickerDialog**: Interactive HSV slider-based color picker with hex input field
- **CustomAccentColorCircle**: New UI element in the accent color row showing the selected custom color with a rainbow gradient when unselected
- **Custom accent color support**: New `AccentColor.CUSTOM` enum value and `customAccentColorArgb` preference field
- **Jellyfin Classic preset**: Added the actual jellyfin-web client palette as a preset option for users who prefer the original look
- **MaterialKolor integration**: Uses `rememberDynamicColorScheme()` with Expressive palette style to generate harmonious Material 3 color schemes from user-picked seed colors
- **Theme updates**: Switched to `MaterialExpressiveTheme` for richer tonal role distinction

## Type of change

- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no functional change)
- [ ] perf (performance improvement)
- [ ] test (add/fix tests)
- [ ] chore (build, tooling, deps)

## How to test

```bash
# Build
./gradlew assembleDebug

# Unit tests
./gradlew testDebugUnitTest

# Lint
./gradlew lintDebug
```

**Manual testing**:
1. Open Settings → Appearance
2. Scroll to "Accent Color" section
3. Tap the new "Custom" color circle (rainbow gradient icon)
4. Adjust Hue, Saturation, and Brightness sliders or enter a hex color code
5. Tap "Apply" to confirm
6. Verify the app theme updates to use the custom color across all screens
7. Restart the app to verify the custom color persists

## Checklist

- [x] Follows Conventional Commits
- [x] Branch named appropriately
- [x] Tests added/updated where applicable
- [x] `./gradlew testDebugUnitTest` passes
- [x] `./gradlew lintDebug` passes
- [x] Docs updated (README/CHANGELOG as needed)
- [x] Affected areas and testing notes included

https://claude.ai/code/session_01NZ2iVm11NkANEphiUgAXKy