### PR TITLE
docs: diagnose broken main-branch test suite (not yet a fix)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -374,6 +374,8 @@ apply(plugin = "jacoco")
 
 tasks.withType<Test> {
     maxHeapSize = "4096m"
-    jvmArgs("-XX:+UseG1GC")
+    // MockK/ByteBuddy self-attach its inline-mocking agent at runtime; JDK 21+ restricts
+    // dynamic agent loading (JEP 451). Without this, mocking final Kotlin classes can fail.
+    jvmArgs("-XX:+UseG1GC", "-XX:+EnableDynamicAgentLoading", "-Djdk.attach.allowAttachSelf=true")
     forkEvery = 1
 }

--- a/docs/development/TESTING_IMPROVEMENT_PLAN.md
+++ b/docs/development/TESTING_IMPROVEMENT_PLAN.md
@@ -14,6 +14,106 @@ This document outlines the steps to stabilize the current test suite, fix existi
 
 ---
 
+## Diagnostic Update (July 2026)
+
+Progress has been made since March (538→626 total tests as coverage grew, 186→~64-67 failing,
+roughly 35%→~10-11%), but `android-ci.yml`'s `build-test-lint` job has still failed on **every
+recorded run on `main`** going back through at least May 27, 2026 (1297 total workflow runs
+checked; all `failure`). This section documents a focused investigation session's findings so the
+next person picking this up doesn't have to re-derive them. **None of the hypotheses below are
+verified by a passing local run or a full stack trace** — this environment had no Android
+SDK/network access (`dl.google.com` blocked by egress policy) and could not download the CI
+`unit-test-reports` artifact (Azure blob storage host also blocked), so all diagnosis was done by
+reading Gradle's default console test-failure summaries (exception type + `File.kt:line` only, no
+message/full stack trace) plus static source reading. Treat everything here as a lead, not a fix.
+
+### Method used to gather this data
+```
+# Get check runs for a PR/commit, then:
+# GitHub Actions job logs (console output) via job ID — only gives "ExceptionType at File:Line"
+# per failing test by default, since no custom testLogging{} block is configured in build.gradle.kts.
+# For a real stack trace + message, download the "unit-test-reports" artifact
+# (app/build/reports/tests/testDebugUnitTest/**, app/build/test-results/testDebugUnitTest/**)
+# from a workflow run and read the XML/HTML — this requires either local network access or being
+# able to reach Azure Blob Storage from CI-adjacent tooling, neither of which this session had.
+```
+
+### What's been tried and measured
+- **Added `-XX:+EnableDynamicAgentLoading -Djdk.attach.allowAttachSelf=true` to `tasks.withType<Test>` JVM args** (this branch, `claude/fix-broken-tests`). Hypothesis: MockK/ByteBuddy self-attaches its inline-mocking agent at runtime to mock final Kotlin classes, and JDK 21+ restricts dynamic agent loading (JEP 451). **Measured effect: 67 → 64 failing tests** (out of 626) — a small improvement, not a fix. Kept in the codebase since it's low-risk and plausibly still relevant, but it is **not** the primary cause of the remaining failures.
+
+### Failure clusters as of the last measured run (64 failing / 626 total)
+Grouped by test class, with exception type and (unreliable — see caveat above) reported line:
+
+1. **`JellyfinStreamRepositoryTest` — 19 tests, all `NullPointerException`.** Every test in the
+   file fails, including the simplest possible one (`getStreamUrl returns null when no server
+   available`, which just stubs `authRepository.getCurrentServer() returns null` and asserts
+   null). The NPE happens at each test's first `every {}`/mock-touching line, which points to the
+   `@MockK(relaxed = true)` mocks of `JellyfinAuthRepository` and `DeviceCapabilities` (both plain
+   `final` Kotlin classes, no interface) being non-functional rather than a logic bug. No
+   `RunWith(RobolectricTestRunner)` or `mockkStatic` in this file, so it's a purer MockK-only
+   signal than the clusters below. **Not fixed by the JDK21 agent-loading change above.**
+   Next step: get a real stack trace for `getStreamUrl returns null when no server available` (see
+   "How to get better data" below) — that single simple case should make the actual failure point
+   obvious.
+
+2. **`JellyfinAuthRepositoryTest` — 9 tests, all `ClassNotFoundException`** reported at
+   `JellyfinAuthRepositoryTest.kt:503` — **a line number that does not exist in the file** (it's
+   254 lines long), meaning Gradle's location attribution is unreliable here and the real throw
+   site is elsewhere (likely inside MockK/generated code). This file combines
+   `@RunWith(RobolectricTestRunner::class)` with three `mockkStatic(...)` calls, two of which are
+   **string-literal class names** guessed from the Jellyfin SDK's internals:
+   `mockkStatic("org.jellyfin.sdk.api.client.extensions.QuickConnectApiKt")` and
+   `...UserApiKt`. The Jellyfin SDK (`jellyfinSdk` in `libs.versions.toml`, currently 1.8.11) is
+   code-generated (OpenAPI + KotlinPoet per the SDK's own repo), so the exact generated
+   file/class name backing an extension property like `ApiClient.quickConnectApi` is an
+   implementation detail, not a stable contract — a SDK version bump could easily change it and
+   silently break these string-based lookups with exactly a `ClassNotFoundException`.
+   **Caveat:** `EnhancedPlaybackManagerTest.kt` uses the same
+   `RobolectricTestRunner` + `mockkStatic(android.util.Log::class)` pattern and is *not* in the
+   current failing list, which argues against "Robolectric + Log mocking is fundamentally broken"
+   as the cause and points more specifically at the two SDK string-literal `mockkStatic` calls.
+   MockK does not allow reference-based (`ClassName::property`) mocking for **extension
+   properties** (only extension functions), so the fix isn't a simple one-line swap — it likely
+   needs either the correct current generated class name (unknown without SDK jar access) or a
+   different mocking strategy for these two properties. `EncryptedPreferencesTest.kt` also uses
+   `RobolectricTestRunner` but has no `mockkStatic` at all — its ~10 failures are a different,
+   simpler story: the test's own comments say it "requires Android test environment, not pure
+   JVM" for real Android Keystore access, and Robolectric's default shadows don't provide a
+   functional `AndroidKeyStore` `Cipher`/`KeyStore` provider, so `encryptValue()` likely fails
+   internally and returns null. This one is probably a legitimate test-environment limitation,
+   not a regression — worth confirming with a real stack trace before doing anything invasive
+   (e.g. don't disable/delete these tests based on speculation).
+
+3. **`HomeViewModelTest` — 6 tests, `AssertionError`/`ComparisonFailure`.** Unlike the two
+   clusters above, these look like genuine expected-vs-actual mismatches (`ComparisonFailure` is
+   JUnit's type for a failed `assertEquals`, not an infra crash), i.e. real test/logic drift that
+   probably needs case-by-case comparison against current `MainAppViewModel`/`HomeViewModel`
+   behavior rather than an infra fix.
+
+4. **Scattered 1-2 test failures across many other files** — `CertificatePinningManagerTest`,
+   `PinningTrustManagerTest`, `PlaybackProgressManagerTest`, `RepositoryUtilsTest`,
+   `ThemeTest` (3 — pre-existing, unrelated to the PR #1165 theming work, confirmed present on
+   `main` before those changes), `JellyfinAuthRefreshManagerTest`, `AudioPlaybackViewModelTest`,
+   `MainAppViewModelHomeVideosTest`, `MainAppViewModelLibraryLoadTest`,
+   `ServerConnectionViewModelTest`/`ServerConnectionViewModelOfflineTest`,
+   `TVEpisodeDetailViewModelTest`. The exact set fluctuates slightly run-to-run (64-72 failures
+   observed across different runs on the same commit), suggesting some genuine flakiness on top
+   of the deterministic clusters above. Each of these needs individual investigation; no shared
+   pattern was found among them in this session.
+
+### How to get better data before attempting more fixes
+The single highest-leverage next step is getting one real stack trace instead of guessing:
+```bash
+./gradlew testDebugUnitTest --tests "*.JellyfinStreamRepositoryTest" --tests "*.JellyfinAuthRepositoryTest" --stacktrace
+# or open app/build/reports/tests/testDebugUnitTest/index.html after any run
+```
+Either locally, or by downloading the `unit-test-reports` artifact from a recent
+`android-ci.yml` run (Actions tab → run → Artifacts). That will immediately confirm or rule out
+the `ClassNotFoundException`/NPE hypotheses above and turn this from "likely leads" into "known
+fixes."
+
+---
+
 ## Phase 1: Stabilization (Fixing Existing Failures)
 
 The primary goal is to reach a "Green" state (100% passing) by resolving systemic issues.


### PR DESCRIPTION
## Summary

- `main`'s `build-test-lint` CI job has failed on every recorded run going back through at least May 27, 2026 (1297 runs checked). This is a pre-existing, previously-tracked issue (`docs/development/TESTING_IMPROVEMENT_PLAN.md`, ~35% failure rate in March 2026, ~10-11% now — some progress made, not resolved).
- **This PR is now a diagnostic write-up, not a confirmed fix.** After two rounds of investigation without being able to run the build or retrieve real stack traces locally (no Android SDK/network access in my environment; the CI artifact host with full XML test reports is also blocked by egress policy), I don't have enough confidence to keep pushing speculative code changes.
- `docs/development/TESTING_IMPROVEMENT_PLAN.md` now has a detailed "Diagnostic Update (July 2026)" section: failure clusters, exception types, line numbers, what's been ruled out, and what data would unblock a real fix (a single stack trace from `./gradlew testDebugUnitTest --tests "*.JellyfinStreamRepositoryTest" --stacktrace` or the CI `unit-test-reports` artifact).
- One small, low-risk, measured change is included: `-XX:+EnableDynamicAgentLoading -Djdk.attach.allowAttachSelf=true` JVM args for the test task (JDK 21 JEP 451 workaround for MockK). Measured effect: 67→64 failing tests — a minor improvement, not a fix, but harmless to keep.

## Type of change

- [x] docs (documentation only)
- [x] chore (build, tooling, deps) — the JVM args change
- [ ] fix (bug fix) — intentionally not claiming this yet, see above

## How to test

```bash
./gradlew testDebugUnitTest --tests "*.JellyfinStreamRepositoryTest" --tests "*.JellyfinAuthRepositoryTest" --stacktrace
```

## Checklist

- [x] Follows Conventional Commits
- [x] Branch named appropriately
- [ ] Tests added/updated where applicable — N/A, this is diagnosis
- [ ] `./gradlew testDebugUnitTest` passes — not yet, that's the point of this PR
- [ ] `./gradlew lintDebug` passes
- [x] Docs updated
- [x] Affected areas and testing notes included
