### PR TITLE
Improve audio playback reliability and audiobook resume

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/ui/player/PlaybackProgressManager.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/player/PlaybackProgressManager.kt
@@ -31,6 +31,7 @@ data class PlaybackProgress(
     val durationMs: Long = 0L,
     val percentageWatched: Float = 0f,
     val isWatched: Boolean = false,
+    val isPaused: Boolean = false,
     val lastSyncTime: Long = 0L,
 )
 
@@ -99,7 +100,7 @@ class PlaybackProgressManager @Inject constructor(
         }
     }
 
-    fun updateProgress(positionMs: Long, durationMs: Long) {
+    fun updateProgress(positionMs: Long, durationMs: Long, isPaused: Boolean = false) {
         if (currentItemId.isEmpty() || durationMs <= 0) return
 
         if (hasReportedStop) {
@@ -115,7 +116,8 @@ class PlaybackProgressManager @Inject constructor(
         // Throttle state updates to prevent excessive recompositions (max 2 per second)
         // Only update state if enough time has passed OR if there's a significant change
         val shouldUpdateState = (currentTime - lastStateUpdateTime >= STATE_UPDATE_THROTTLE_MS) ||
-            kotlin.math.abs(positionMs - _playbackProgress.value.positionMs) >= MIN_POSITION_CHANGE
+            kotlin.math.abs(positionMs - _playbackProgress.value.positionMs) >= MIN_POSITION_CHANGE ||
+            _playbackProgress.value.isPaused != isPaused
 
         if (shouldUpdateState) {
             _playbackProgress.update {
@@ -125,6 +127,7 @@ class PlaybackProgressManager @Inject constructor(
                     durationMs = durationMs,
                     percentageWatched = percentageWatched,
                     isWatched = isWatched,
+                    isPaused = isPaused,
                 )
             }
             lastStateUpdateTime = currentTime
@@ -134,7 +137,7 @@ class PlaybackProgressManager @Inject constructor(
             hasReportedStart = true
             // Use managed scope for fire-and-forget reporting
             managerScope.launch {
-                reportPlaybackStart(positionMs, durationMs)
+                reportPlaybackStart(positionMs, durationMs, isPaused)
             }
         }
 
@@ -148,7 +151,7 @@ class PlaybackProgressManager @Inject constructor(
         // Report progress to server if significant change
         if (kotlin.math.abs(positionMs - lastReportedPosition) >= MIN_POSITION_CHANGE) {
             managerScope.launch {
-                reportProgress(positionMs, durationMs, isWatched)
+                reportProgress(positionMs, durationMs, isWatched, isPaused)
             }
             lastReportedPosition = positionMs
         }
@@ -208,7 +211,7 @@ class PlaybackProgressManager @Inject constructor(
         // Final progress report
         val progress = _playbackProgress.value
         if (progress.itemId.isNotEmpty()) {
-            reportProgress(progress.positionMs, progress.durationMs, progress.isWatched)
+            reportProgress(progress.positionMs, progress.durationMs, progress.isWatched, progress.isPaused)
             if (reportStop && !hasReportedStop) {
                 reportPlaybackStop(progress.positionMs, progress.durationMs)
                 hasReportedStop = true
@@ -250,15 +253,13 @@ class PlaybackProgressManager @Inject constructor(
 
     override fun onPause(owner: LifecycleOwner) {
         super.onPause(owner)
-        // On backgrounding, emit both PROGRESS and STOPPED once so offline queue captures pause/stop transitions.
+        // The app moving to the background does not mean media playback stopped. Audio can
+        // continue in AudioService, so only flush the latest state here. Player owners are
+        // responsible for sending STOPPED when playback actually ends.
         managerScope.launch {
             val progress = _playbackProgress.value
             if (progress.itemId.isNotEmpty()) {
-                reportProgress(progress.positionMs, progress.durationMs, progress.isWatched)
-                if (!hasReportedStop) {
-                    reportPlaybackStop(progress.positionMs, progress.durationMs)
-                    hasReportedStop = true
-                }
+                reportProgress(progress.positionMs, progress.durationMs, progress.isWatched, progress.isPaused)
             }
         }
     }
@@ -278,7 +279,7 @@ class PlaybackProgressManager @Inject constructor(
                 delay(PROGRESS_SYNC_INTERVAL)
                 val progress = _playbackProgress.value
                 if (progress.itemId.isNotEmpty()) {
-                    reportProgress(progress.positionMs, progress.durationMs, progress.isWatched)
+                    reportProgress(progress.positionMs, progress.durationMs, progress.isWatched, progress.isPaused)
                 }
             }
         }
@@ -295,7 +296,12 @@ class PlaybackProgressManager @Inject constructor(
         }
     }
 
-    private suspend fun reportProgress(positionMs: Long, durationMs: Long, isWatched: Boolean) {
+    private suspend fun reportProgress(
+        positionMs: Long,
+        durationMs: Long,
+        isWatched: Boolean,
+        isPaused: Boolean,
+    ) {
         if (currentItemId.isEmpty()) return
 
         // Always save to offline manager for local resume support
@@ -309,7 +315,7 @@ class PlaybackProgressManager @Inject constructor(
                 positionTicks = ticks,
                 mediaSourceId = mediaSourceId,
                 playMethod = playMethod,
-                isPaused = false,
+                isPaused = isPaused,
                 canSeek = durationMs > 0,
             )
 
@@ -339,7 +345,7 @@ class PlaybackProgressManager @Inject constructor(
                         result.errorType == com.rpeters.jellyfin.data.repository.common.ErrorType.UNAUTHORIZED
                     ) {
                         Log.w("PlaybackProgressManager", "Session $sessionId timed out or not found, re-reporting start")
-                        reportPlaybackStart(positionMs, durationMs)
+                        reportPlaybackStart(positionMs, durationMs, isPaused)
                     }
                 }
                 else -> Unit
@@ -351,7 +357,7 @@ class PlaybackProgressManager @Inject constructor(
         }
     }
 
-    private suspend fun reportPlaybackStart(positionMs: Long, durationMs: Long) {
+    private suspend fun reportPlaybackStart(positionMs: Long, durationMs: Long, isPaused: Boolean = false) {
         if (currentItemId.isEmpty()) return
         try {
             val ticks = positionMs.toTicks()
@@ -361,7 +367,7 @@ class PlaybackProgressManager @Inject constructor(
                 positionTicks = ticks,
                 mediaSourceId = mediaSourceId,
                 playMethod = playMethod,
-                isPaused = false,
+                isPaused = isPaused,
                 canSeek = durationMs > 0,
             )
             if (result is ApiResult.Error) {

--- a/app/src/main/java/com/rpeters/jellyfin/ui/player/audio/AudioService.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/player/audio/AudioService.kt
@@ -173,6 +173,11 @@ class AudioService : androidx.media3.session.MediaSessionService() {
 
                 override fun onIsPlayingChanged(isPlaying: Boolean) {
                     updateCurrentProgress(isPaused = !isPlaying)
+                    if (isPlaying) {
+                        startProgressUpdates()
+                    } else {
+                        stopProgressUpdates()
+                    }
                 }
 
                 override fun onPlaybackStateChanged(playbackState: Int) {
@@ -214,7 +219,7 @@ class AudioService : androidx.media3.session.MediaSessionService() {
         AudioSessionStateStore(this).persist(player)
         updateCurrentProgress(isPaused = true)
         playbackProgressManager.stopTrackingAsync()
-        progressUpdateJob?.cancel()
+        stopProgressUpdates()
         serviceScope.cancel()
         super.onDestroy()
         notificationProvider = null
@@ -331,24 +336,30 @@ class AudioService : androidx.media3.session.MediaSessionService() {
 
         trackingItemId = newItemId
         if (newItemId == null) {
-            progressUpdateJob?.cancel()
-            progressUpdateJob = null
+            stopProgressUpdates()
             return
         }
 
         playbackProgressManager.startTracking(newItemId, serviceScope)
         updateCurrentProgress(isPaused = !player.isPlaying)
-        startProgressUpdates()
+        if (player.isPlaying) {
+            startProgressUpdates()
+        }
     }
 
     private fun startProgressUpdates() {
         if (progressUpdateJob?.isActive == true) return
         progressUpdateJob = serviceScope.launch {
             while (isActive) {
-                updateCurrentProgress(isPaused = !player.isPlaying)
+                updateCurrentProgress(isPaused = false)
                 delay(PROGRESS_UPDATE_INTERVAL_MS)
             }
         }
+    }
+
+    private fun stopProgressUpdates() {
+        progressUpdateJob?.cancel()
+        progressUpdateJob = null
     }
 
     private fun updateCurrentProgress(isPaused: Boolean) {
@@ -365,8 +376,7 @@ class AudioService : androidx.media3.session.MediaSessionService() {
     private fun stopProgressTracking() {
         if (trackingItemId == null) return
         trackingItemId = null
-        progressUpdateJob?.cancel()
-        progressUpdateJob = null
+        stopProgressUpdates()
         playbackProgressManager.stopTrackingAsync()
     }
 

--- a/app/src/main/java/com/rpeters/jellyfin/ui/player/audio/AudioService.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/player/audio/AudioService.kt
@@ -20,7 +20,17 @@ import androidx.media3.session.MediaSession
 import androidx.media3.session.SessionCommand
 import androidx.media3.session.SessionResult
 import com.google.common.util.concurrent.Futures
+import com.rpeters.jellyfin.data.repository.JellyfinStreamRepository
+import com.rpeters.jellyfin.ui.player.PlaybackProgressManager
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 import org.json.JSONArray
 import org.json.JSONObject
 import javax.inject.Inject
@@ -32,9 +42,18 @@ class AudioService : androidx.media3.session.MediaSessionService() {
     @Inject
     lateinit var foregroundIntentProvider: AudioServiceForegroundIntentProvider
 
+    @Inject
+    lateinit var playbackProgressManager: PlaybackProgressManager
+
+    @Inject
+    lateinit var streamRepository: JellyfinStreamRepository
+
     private var mediaSession: MediaSession? = null
     private var notificationProvider: DefaultMediaNotificationProvider? = null
     private lateinit var player: ExoPlayer
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private var progressUpdateJob: Job? = null
+    private var trackingItemId: String? = null
 
     override fun onCreate() {
         super.onCreate()
@@ -147,8 +166,27 @@ class AudioService : androidx.media3.session.MediaSessionService() {
                     syncSessionUiState()
                     AudioSessionStateStore(this@AudioService).persist(player)
                 }
+
+                override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
+                    serviceScope.launch { switchProgressTracking(mediaItem) }
+                }
+
+                override fun onIsPlayingChanged(isPlaying: Boolean) {
+                    updateCurrentProgress(isPaused = !isPlaying)
+                }
+
+                override fun onPlaybackStateChanged(playbackState: Int) {
+                    if (playbackState == Player.STATE_ENDED) {
+                        updateCurrentProgress(isPaused = true)
+                        stopProgressTracking()
+                    }
+                }
             },
         )
+
+        player.currentMediaItem?.let { restoredItem ->
+            serviceScope.launch { switchProgressTracking(restoredItem) }
+        }
 
         notificationProvider = AudioNotificationProvider(this).apply {
             // Use a valid monochrome small icon resource
@@ -174,6 +212,10 @@ class AudioService : androidx.media3.session.MediaSessionService() {
 
     override fun onDestroy() {
         AudioSessionStateStore(this).persist(player)
+        updateCurrentProgress(isPaused = true)
+        playbackProgressManager.stopTrackingAsync()
+        progressUpdateJob?.cancel()
+        serviceScope.cancel()
         super.onDestroy()
         notificationProvider = null
         mediaSession?.release()
@@ -183,7 +225,13 @@ class AudioService : androidx.media3.session.MediaSessionService() {
 
     private fun resolveMediaItem(item: MediaItem): MediaItem {
         val extras = item.mediaMetadata.extras ?: Bundle.EMPTY
-        val streamUrl = extras.getString(EXTRA_STREAM_URL)
+        val persistedStreamUrl = extras.getString(EXTRA_STREAM_URL)
+        val shouldRefreshStreamUrl = extras.getBoolean(EXTRA_REFRESH_STREAM_URL, false)
+        val streamUrl = if (shouldRefreshStreamUrl && item.mediaId.isNotBlank()) {
+            streamRepository.getStreamUrl(item.mediaId) ?: persistedStreamUrl
+        } else {
+            persistedStreamUrl
+        }
         val artworkUri = extras.getString(EXTRA_ARTWORK_URI)
         val metadataBuilder = item.mediaMetadata.buildUpon()
 
@@ -218,7 +266,7 @@ class AudioService : androidx.media3.session.MediaSessionService() {
             TransportCommand.SkipNext -> player.seekToNextMediaItem()
             TransportCommand.SkipPrevious -> player.seekToPreviousMediaItem()
             TransportCommand.SeekForward -> {
-                val boundedPosition = if (player.duration == C.TIME_UNSET) {
+                val boundedPosition = if (player.duration == C.TIME_UNSET || player.duration < 0L) {
                     player.currentPosition + SEEK_INTERVAL_MS
                 } else {
                     (player.currentPosition + SEEK_INTERVAL_MS).coerceAtMost(player.duration)
@@ -227,6 +275,8 @@ class AudioService : androidx.media3.session.MediaSessionService() {
             }
             TransportCommand.SeekBackward -> player.seekTo((player.currentPosition - SEEK_INTERVAL_MS).coerceAtLeast(0))
             TransportCommand.Stop -> {
+                updateCurrentProgress(isPaused = true)
+                stopProgressTracking()
                 player.pause()
                 player.stop()
                 player.clearMediaItems()
@@ -260,7 +310,7 @@ class AudioService : androidx.media3.session.MediaSessionService() {
     private fun restoreSessionState(state: PersistedAudioSessionState) {
         if (state.queue.isNotEmpty()) {
             player.setMediaItems(
-                state.queue,
+                state.queue.map(::resolveMediaItem),
                 state.currentIndex.coerceIn(0, state.queue.lastIndex),
                 state.currentPositionMs.coerceAtLeast(0L),
             )
@@ -269,6 +319,55 @@ class AudioService : androidx.media3.session.MediaSessionService() {
             player.playWhenReady = state.playWhenReady
             player.prepare()
         }
+    }
+
+    private suspend fun switchProgressTracking(mediaItem: MediaItem?) {
+        val newItemId = mediaItem?.mediaId?.takeIf { it.isNotBlank() }
+        if (trackingItemId == newItemId) return
+
+        if (trackingItemId != null) {
+            playbackProgressManager.stopTracking()
+        }
+
+        trackingItemId = newItemId
+        if (newItemId == null) {
+            progressUpdateJob?.cancel()
+            progressUpdateJob = null
+            return
+        }
+
+        playbackProgressManager.startTracking(newItemId, serviceScope)
+        updateCurrentProgress(isPaused = !player.isPlaying)
+        startProgressUpdates()
+    }
+
+    private fun startProgressUpdates() {
+        if (progressUpdateJob?.isActive == true) return
+        progressUpdateJob = serviceScope.launch {
+            while (isActive) {
+                updateCurrentProgress(isPaused = !player.isPlaying)
+                delay(PROGRESS_UPDATE_INTERVAL_MS)
+            }
+        }
+    }
+
+    private fun updateCurrentProgress(isPaused: Boolean) {
+        if (trackingItemId == null) return
+        val duration = player.duration
+        if (duration == C.TIME_UNSET || duration <= 0L) return
+        playbackProgressManager.updateProgress(
+            positionMs = player.currentPosition.coerceAtLeast(0L),
+            durationMs = duration,
+            isPaused = isPaused,
+        )
+    }
+
+    private fun stopProgressTracking() {
+        if (trackingItemId == null) return
+        trackingItemId = null
+        progressUpdateJob?.cancel()
+        progressUpdateJob = null
+        playbackProgressManager.stopTrackingAsync()
     }
 
     private fun buildMediaButtonPreferences(player: Player): List<CommandButton> {
@@ -327,8 +426,11 @@ class AudioService : androidx.media3.session.MediaSessionService() {
         const val EXTRA_DURATION = "com.rpeters.jellyfin.audio.DURATION"
         const val EXTRA_QUEUE_SIZE = "com.rpeters.jellyfin.audio.QUEUE_SIZE"
         const val EXTRA_QUEUE_INDEX = "com.rpeters.jellyfin.audio.QUEUE_INDEX"
+        const val EXTRA_MEDIA_KIND = "com.rpeters.jellyfin.audio.MEDIA_KIND"
+        internal const val EXTRA_REFRESH_STREAM_URL = "com.rpeters.jellyfin.audio.REFRESH_STREAM_URL"
 
         private const val SEEK_INTERVAL_MS = 10_000L
+        private const val PROGRESS_UPDATE_INTERVAL_MS = 1_000L
     }
 }
 
@@ -409,17 +511,25 @@ private class AudioSessionStateStore(
             put("albumTitle", metadata.albumTitle?.toString().orEmpty())
             put("artworkUri", metadata.artworkUri?.toString().orEmpty())
             put("streamUrl", extras?.getString(AudioService.EXTRA_STREAM_URL).orEmpty())
+            put("itemId", extras?.getString(AudioService.EXTRA_ITEM_ID).orEmpty())
+            put("duration", extras?.getLong(AudioService.EXTRA_DURATION) ?: 0L)
+            put("mediaKind", extras?.getString(AudioService.EXTRA_MEDIA_KIND).orEmpty())
         }
     }
 
     private fun jsonToMediaItem(json: JSONObject): MediaItem {
         val extras = Bundle().apply {
             putString(AudioService.EXTRA_STREAM_URL, json.optString("streamUrl"))
+            putString(AudioService.EXTRA_ITEM_ID, json.optString("itemId"))
+            putLong(AudioService.EXTRA_DURATION, json.optLong("duration"))
+            putString(AudioService.EXTRA_MEDIA_KIND, json.optString("mediaKind"))
+            putBoolean(AudioService.EXTRA_REFRESH_STREAM_URL, true)
         }
         val metadata = MediaMetadata.Builder()
             .setTitle(json.optString("title"))
             .setArtist(json.optString("artist"))
             .setAlbumTitle(json.optString("albumTitle"))
+            .setDurationMs(json.optLong("duration"))
             .setArtworkUri(json.optString("artworkUri").takeIf { it.isNotBlank() }?.let(Uri::parse))
             .setExtras(extras)
             .build()

--- a/app/src/main/java/com/rpeters/jellyfin/ui/player/audio/AudioServiceConnection.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/player/audio/AudioServiceConnection.kt
@@ -10,7 +10,6 @@ import androidx.media3.common.util.UnstableApi
 import androidx.media3.session.MediaController
 import androidx.media3.session.SessionToken
 import com.google.common.util.concurrent.ListenableFuture
-import com.rpeters.jellyfin.ui.player.PlaybackProgressManager
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineExceptionHandler
@@ -35,7 +34,6 @@ import java.util.concurrent.CancellationException as FutureCancellationException
 @Singleton
 class AudioServiceConnection @Inject constructor(
     @ApplicationContext private val appContext: Context,
-    private val playbackProgressManager: PlaybackProgressManager,
 ) {
 
     private val controllerScope = CoroutineScope(
@@ -49,8 +47,7 @@ class AudioServiceConnection @Inject constructor(
     )
     private var controllerFuture: ListenableFuture<MediaController>? = null
     private var mediaController: MediaController? = null
-    private var progressUpdateJob: Job? = null
-    private var currentTrackingItemId: String? = null
+    private var positionUpdateJob: Job? = null
 
     private val _playbackState = kotlinx.coroutines.flow.MutableStateFlow(AudioPlaybackState())
     private val _queueState = kotlinx.coroutines.flow.MutableStateFlow<List<MediaItem>>(emptyList())
@@ -63,19 +60,8 @@ class AudioServiceConnection @Inject constructor(
             }
         }
 
-        override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
-            // Track changed - report progress for previous item and start tracking new one
-            controllerScope.launch {
-                handleTrackChange(mediaItem)
-            }
-        }
-
         override fun onIsPlayingChanged(isPlaying: Boolean) {
-            if (isPlaying) {
-                startProgressUpdates()
-            } else {
-                stopProgressUpdates()
-            }
+            if (isPlaying) startPositionUpdates() else stopPositionUpdates()
         }
     }
 
@@ -85,10 +71,28 @@ class AudioServiceConnection @Inject constructor(
     val queueState: kotlinx.coroutines.flow.StateFlow<List<MediaItem>>
         get() = _queueState
 
-    fun playNow(mediaItem: MediaItem) {
+    fun playNow(mediaItem: MediaItem, startPositionMs: Long = 0L) {
         controllerScope.launch {
             val controller = ensureController()
-            controller.setMediaItem(mediaItem)
+            controller.setMediaItem(mediaItem, startPositionMs.coerceAtLeast(0L))
+            controller.prepare()
+            controller.play()
+        }
+    }
+
+    fun playQueue(
+        mediaItems: List<MediaItem>,
+        startIndex: Int = 0,
+        startPositionMs: Long = 0L,
+    ) {
+        if (mediaItems.isEmpty()) return
+        controllerScope.launch {
+            val controller = ensureController()
+            controller.setMediaItems(
+                mediaItems,
+                startIndex.coerceIn(mediaItems.indices),
+                startPositionMs.coerceAtLeast(0L),
+            )
             controller.prepare()
             controller.play()
         }
@@ -161,7 +165,13 @@ class AudioServiceConnection @Inject constructor(
     fun seekForward(amountMs: Long) {
         controllerScope.launch {
             val controller = ensureController()
-            val newPosition = (controller.currentPosition + amountMs).coerceAtMost(controller.duration)
+            val duration = controller.duration
+            val requestedPosition = controller.currentPosition + amountMs
+            val newPosition = if (duration == androidx.media3.common.C.TIME_UNSET || duration < 0L) {
+                requestedPosition
+            } else {
+                requestedPosition.coerceAtMost(duration)
+            }
             controller.seekTo(newPosition)
         }
     }
@@ -227,6 +237,7 @@ class AudioServiceConnection @Inject constructor(
                 _playbackState.value = _playbackState.value.copy(isConnected = true)
                 updatePlaybackState(controller)
                 updateQueue(controller)
+                if (controller.isPlaying) startPositionUpdates()
                 controller
             } catch (exception: Exception) {
                 controllerFuture = null
@@ -243,15 +254,7 @@ class AudioServiceConnection @Inject constructor(
     }
 
     fun releaseController() {
-        // Stop progress tracking
-        stopProgressUpdates()
-        controllerScope.launch {
-            if (currentTrackingItemId != null) {
-                playbackProgressManager.stopTracking()
-                currentTrackingItemId = null
-            }
-        }
-
+        stopPositionUpdates()
         mediaController?.let { controller ->
             try {
                 controller.removeListener(controllerListener)
@@ -298,57 +301,24 @@ class AudioServiceConnection @Inject constructor(
         _queueState.value = items
     }
 
-    private suspend fun handleTrackChange(newMediaItem: MediaItem?) {
-        // Stop tracking previous item
-        if (currentTrackingItemId != null) {
-            playbackProgressManager.stopTracking()
-        }
-
-        // Start tracking new item
-        val itemId = newMediaItem?.mediaId
-        if (!itemId.isNullOrBlank()) {
-            currentTrackingItemId = itemId
-            playbackProgressManager.startTracking(itemId, controllerScope)
-            Log.d(TAG, "Started tracking audio progress for item: $itemId")
-        } else {
-            currentTrackingItemId = null
-        }
-    }
-
-    private fun startProgressUpdates() {
-        if (progressUpdateJob?.isActive == true) return
-
-        progressUpdateJob = controllerScope.launch {
+    private fun startPositionUpdates() {
+        if (positionUpdateJob?.isActive == true) return
+        positionUpdateJob = controllerScope.launch {
             while (isActive) {
-                mediaController?.let { controller ->
-                    updatePlaybackState(controller)
-                    val position = controller.currentPosition
-                    val duration = controller.duration
-                    if (duration > 0 && currentTrackingItemId != null) {
-                        playbackProgressManager.updateProgress(position, duration)
-                    }
-                }
-                delay(PROGRESS_UPDATE_INTERVAL)
+                mediaController?.let(::updatePlaybackState)
+                delay(POSITION_UPDATE_INTERVAL_MS)
             }
         }
     }
 
-    private fun stopProgressUpdates() {
-        progressUpdateJob?.cancel()
-        progressUpdateJob = null
-
-        // Report final position when pausing
-        mediaController?.let { controller ->
-            val position = controller.currentPosition
-            val duration = controller.duration
-            if (duration > 0 && currentTrackingItemId != null) {
-                playbackProgressManager.updateProgress(position, duration)
-            }
-        }
+    private fun stopPositionUpdates() {
+        positionUpdateJob?.cancel()
+        positionUpdateJob = null
+        mediaController?.let(::updatePlaybackState)
     }
 
     companion object {
-        private const val PROGRESS_UPDATE_INTERVAL = 500L // keep UI progress reasonably smooth
+        private const val POSITION_UPDATE_INTERVAL_MS = 500L
     }
 }
 

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/MusicScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/MusicScreen.kt
@@ -577,7 +577,12 @@ private fun ActivePlaybackPanel(
             }
 
             ExpressiveWavyLinearProgress(
-                progress = if (playbackState.isPlaying) 0.42f else 0.18f,
+                progress = if (playbackState.duration > 0L) {
+                    (playbackState.currentPosition.toFloat() / playbackState.duration.toFloat())
+                        .coerceIn(0f, 1f)
+                } else {
+                    0f
+                },
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(6.dp),

--- a/app/src/main/java/com/rpeters/jellyfin/ui/utils/MediaPlayerUtils.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/utils/MediaPlayerUtils.kt
@@ -100,7 +100,12 @@ object MediaPlayerUtils {
         }
         val artworkUrl = entryPoint.jellyfinStreamRepository().getImageUrl(artworkItemId, "Primary", null)
         val mediaItem = buildAudioMediaItem(item, streamUrl, artworkUrl)
-        connection.playNow(mediaItem)
+        val resumePositionMs = if (item.type == BaseItemKind.AUDIO_BOOK) {
+            item.userData?.playbackPositionTicks?.div(10_000L) ?: 0L
+        } else {
+            0L
+        }
+        connection.playNow(mediaItem, resumePositionMs)
     }
 
     private fun buildAudioMediaItem(
@@ -116,6 +121,10 @@ object MediaPlayerUtils {
             putString(AudioService.EXTRA_ALBUM_NAME, item.album ?: item.albumId?.toString())
             putString(AudioService.EXTRA_ARTIST_NAME, item.albumArtist ?: item.artists?.firstOrNull())
             putLong(AudioService.EXTRA_DURATION, (item.runTimeTicks ?: 0L) / 10_000)
+            putString(
+                AudioService.EXTRA_MEDIA_KIND,
+                if (item.type == BaseItemKind.AUDIO_BOOK) AudioMediaKind.AUDIOBOOK.name else AudioMediaKind.MUSIC.name,
+            )
         }
 
         val mediaMetadata = MediaMetadata.Builder()
@@ -260,6 +269,11 @@ object MediaPlayerUtils {
             throw e
         }
     }
+}
+
+enum class AudioMediaKind {
+    MUSIC,
+    AUDIOBOOK,
 }
 
 class MediaPlayerException(message: String, cause: Throwable? = null) : Exception(message, cause)

--- a/app/src/main/java/com/rpeters/jellyfin/ui/viewmodel/AudioPlaybackViewModel.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/viewmodel/AudioPlaybackViewModel.kt
@@ -68,8 +68,16 @@ class AudioPlaybackViewModel @Inject constructor(
         audioServiceConnection.seekBackward(amountMs)
     }
 
-    fun playMediaItem(mediaItem: MediaItem) {
-        audioServiceConnection.playNow(mediaItem)
+    fun playMediaItem(mediaItem: MediaItem, startPositionMs: Long = 0L) {
+        audioServiceConnection.playNow(mediaItem, startPositionMs)
+    }
+
+    fun playQueue(
+        mediaItems: List<MediaItem>,
+        startIndex: Int = 0,
+        startPositionMs: Long = 0L,
+    ) {
+        audioServiceConnection.playQueue(mediaItems, startIndex, startPositionMs)
     }
 
     fun addToQueue(mediaItem: MediaItem) {

--- a/app/src/test/java/com/rpeters/jellyfin/ui/player/PlaybackProgressManagerTest.kt
+++ b/app/src/test/java/com/rpeters/jellyfin/ui/player/PlaybackProgressManagerTest.kt
@@ -93,6 +93,38 @@ class PlaybackProgressManagerTest {
     }
 
     @Test
+    fun `paused playback is reported as paused without stopping the session`() = runTest(testDispatcher) {
+        val itemId = "paused"
+        val sessionId = "paused-session"
+        coEvery { repository.getItemUserData(itemId) } returns ApiResult.Success(userData())
+        coEvery { repository.reportPlaybackStart(any(), any(), any(), any(), any(), any(), any()) } returns ApiResult.Success(Unit)
+        coEvery { repository.reportPlaybackProgress(any(), any(), any(), any(), any(), any(), any()) } returns ApiResult.Success(Unit)
+        coEvery { repository.reportPlaybackStopped(any(), any(), any(), any(), any()) } returns ApiResult.Success(Unit)
+
+        manager.startTracking(itemId, this, sessionId)
+        runCurrent()
+        manager.updateProgress(positionMs = 6_000L, durationMs = 20_000L, isPaused = true)
+        runCurrent()
+
+        assertTrue(manager.playbackProgress.value.isPaused)
+        coVerify {
+            repository.reportPlaybackProgress(
+                itemId,
+                sessionId,
+                60_000_000L,
+                null,
+                org.jellyfin.sdk.model.api.PlayMethod.DIRECT_PLAY,
+                true,
+                false,
+                true,
+            )
+        }
+
+        manager.stopTracking()
+        runCurrent()
+    }
+
+    @Test
     fun `markAsWatched updates state on success`() = runTest(testDispatcher) {
         val itemId = "watched"
         coEvery { repository.getItemUserData(itemId) } returns ApiResult.Success(userData())

--- a/app/src/test/java/com/rpeters/jellyfin/ui/viewmodel/AudioPlaybackViewModelTest.kt
+++ b/app/src/test/java/com/rpeters/jellyfin/ui/viewmodel/AudioPlaybackViewModelTest.kt
@@ -238,7 +238,28 @@ class AudioPlaybackViewModelTest {
         viewModel.playMediaItem(mediaItem)
 
         // Then
-        verify(exactly = 1) { audioServiceConnection.playNow(mediaItem) }
+        verify(exactly = 1) { audioServiceConnection.playNow(mediaItem, 0L) }
+    }
+
+    @Test
+    fun `playMediaItem delegates resume position to service connection`() = runTest(testDispatcher) {
+        val mediaItem = mockk<MediaItem>(relaxed = true)
+
+        viewModel.playMediaItem(mediaItem, startPositionMs = 42_000L)
+
+        verify(exactly = 1) { audioServiceConnection.playNow(mediaItem, 42_000L) }
+    }
+
+    @Test
+    fun `playQueue delegates queue start information to service connection`() = runTest(testDispatcher) {
+        val mediaItems = listOf(
+            mockk<MediaItem>(relaxed = true),
+            mockk<MediaItem>(relaxed = true),
+        )
+
+        viewModel.playQueue(mediaItems, startIndex = 1, startPositionMs = 12_000L)
+
+        verify(exactly = 1) { audioServiceConnection.playQueue(mediaItems, 1, 12_000L) }
     }
 
     @Test


### PR DESCRIPTION
## What changed

- move Jellyfin audio progress/session ownership from the UI-side MediaController connection into AudioService
- keep reporting active while the app UI is backgrounded or disconnected
- report the real paused state instead of always sending isPaused=false
- stop treating app backgrounding as playback stopped
- resume audiobook items from Jellyfin playbackPositionTicks
- add atomic queue playback with start index and start position support
- refresh restored stream URLs from stable Jellyfin item IDs, with the persisted URL as fallback
- preserve duration and media-kind metadata across service recreation
- safely seek when Media3 reports an unknown duration
- replace the Music screen's placeholder progress values with actual playback progress
- add tests for paused reporting, resumed playback delegation, and atomic queue delegation

## Why

Audio playback could continue in MediaSessionService after the UI controller stopped owning progress tracking. That could leave Jellyfin with stale progress or a false STOPPED event. Audiobooks also always restarted from zero even when Jellyfin had a saved position.

## Validation

- `git diff --check` passes
- GitHub Actions **Build debug APK** passes
- dependency report and dependency review pass
- the new paused-reporting and queue/resume delegation tests are not among the failing tests
- the repository-wide unit task currently reports its existing broad baseline of 72 failures across authentication, encryption, themes, repositories, and unrelated ViewModels; because that aggregate step fails, later lint and warning-budget steps are skipped
- local Gradle execution could not download the Gradle distribution because the cloud sandbox cannot reach services.gradle.org
