### PR TITLE
Add auto-hide header to Music screen and improve Artist detail UX

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/data/repository/JellyfinMediaRepository.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/data/repository/JellyfinMediaRepository.kt
@@ -328,9 +328,15 @@ class JellyfinMediaRepository @Inject constructor(
         withServerClient("getAlbumsForArtist") { server, client ->
             val userUuid = parseUuid(server.userId ?: "", "user")
             val artistUuid = parseUuid(artistId, "artist")
+            // MusicArtist entities are virtual/aggregated in Jellyfin — they are not the
+            // literal folder parent of MusicAlbum items, so querying with parentId returns
+            // nothing. Use artistIds (matches the server's /Items?ArtistIds= query param)
+            // together with recursive = true, which is how the official web client and
+            // other Jellyfin clients (e.g. Finamp) look up an artist's albums.
             val response = client.itemsApi.getItems(
                 userId = userUuid,
-                parentId = artistUuid,
+                artistIds = listOf(artistUuid),
+                recursive = true,
                 includeItemTypes = listOf(BaseItemKind.MUSIC_ALBUM),
                 sortBy = listOf(ItemSortBy.SORT_NAME),
                 sortOrder = listOf(SortOrder.ASCENDING),

--- a/app/src/main/java/com/rpeters/jellyfin/ui/JellyfinApp.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/JellyfinApp.kt
@@ -399,9 +399,13 @@ fun JellyfinApp(
                 }
             }
         } else {
-            // No navigation for auth and detail screens
+            // No navigation for auth and detail screens.
+            // Detail screens (e.g. NowPlayingScreen) each own a Scaffold + top app bar that
+            // already consumes the status bar inset, so this outer Scaffold must not reserve
+            // it again - otherwise screens end up with two stacked status-bar-height gaps.
             Scaffold(
                 modifier = Modifier.fillMaxSize(),
+                contentWindowInsets = WindowInsets(0, 0, 0, 0),
                 bottomBar = {
                     // Still show mini player on detail screens if something is playing
                     // Positioned at the very bottom

--- a/app/src/main/java/com/rpeters/jellyfin/ui/components/immersive/TopBarVisibility.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/components/immersive/TopBarVisibility.kt
@@ -5,12 +5,18 @@ import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import kotlin.math.abs
+
+// Scales firstVisibleItemIndex into a synthetic scroll position so comparisons stay
+// monotonic past the first item, instead of collapsing every non-zero index into a single
+// Int.MAX_VALUE sentinel (which froze the hysteresis delta at 0 and left the bar stuck).
+// Comfortably larger than any realistic per-item pixel offset.
+private const val INDEX_POSITION_SCALE = 1_000_000L
 
 /**
  * Scroll-aware top bar visibility with hysteresis to avoid flicker at low scroll velocity.
@@ -26,29 +32,26 @@ fun rememberAutoHideTopBarVisible(
     toggleThresholdPx: Int = 50,
 ): Boolean {
     var isVisible by remember { mutableStateOf(true) }
-    var previousOffset by remember { mutableIntStateOf(0) }
+    var previousPosition by remember { mutableLongStateOf(0L) }
 
     LaunchedEffect(listState, nearTopOffsetPx, toggleThresholdPx) {
         snapshotFlow {
             listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset
         }.collect { (index, offset) ->
-            // Calculate total scroll position
-            val totalOffset = if (index == 0) offset else Int.MAX_VALUE
-
             // Always show at top
-            if (totalOffset <= nearTopOffsetPx) {
+            if (index == 0 && offset <= nearTopOffsetPx) {
                 isVisible = true
-                previousOffset = totalOffset
+                previousPosition = offset.toLong()
                 return@collect
             }
 
-            // Calculate scroll delta
-            val delta = totalOffset - previousOffset
+            val position = index.toLong() * INDEX_POSITION_SCALE + offset
+            val delta = position - previousPosition
 
             // Only toggle if scrolled enough
             if (abs(delta) >= toggleThresholdPx) {
                 isVisible = delta < 0 // Show when scrolling up, hide when scrolling down
-                previousOffset = totalOffset
+                previousPosition = position
             }
         }
     }
@@ -66,29 +69,26 @@ fun rememberAutoHideTopBarVisible(
     toggleThresholdPx: Int = 50,
 ): Boolean {
     var isVisible by remember { mutableStateOf(true) }
-    var previousOffset by remember { mutableIntStateOf(0) }
+    var previousPosition by remember { mutableLongStateOf(0L) }
 
     LaunchedEffect(gridState, nearTopOffsetPx, toggleThresholdPx) {
         snapshotFlow {
             gridState.firstVisibleItemIndex to gridState.firstVisibleItemScrollOffset
         }.collect { (index, offset) ->
-            // Calculate total scroll position
-            val totalOffset = if (index == 0) offset else Int.MAX_VALUE
-
             // Always show at top
-            if (totalOffset <= nearTopOffsetPx) {
+            if (index == 0 && offset <= nearTopOffsetPx) {
                 isVisible = true
-                previousOffset = totalOffset
+                previousPosition = offset.toLong()
                 return@collect
             }
 
-            // Calculate scroll delta
-            val delta = totalOffset - previousOffset
+            val position = index.toLong() * INDEX_POSITION_SCALE + offset
+            val delta = position - previousPosition
 
             // Only toggle if scrolled enough
             if (abs(delta) >= toggleThresholdPx) {
                 isVisible = delta < 0 // Show when scrolling up, hide when scrolling down
-                previousOffset = totalOffset
+                previousPosition = position
             }
         }
     }

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/ArtistDetailScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/ArtistDetailScreen.kt
@@ -121,12 +121,12 @@ fun ArtistDetailScreen(
                             tint = MusicGreen.copy(alpha = 0.6f),
                         )
                         Text(
-                            text = "No albums found",
+                            text = stringResource(id = R.string.no_albums_found),
                             style = MaterialTheme.typography.headlineSmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
                         Text(
-                            text = "This artist doesn't have any albums in your library yet",
+                            text = stringResource(id = R.string.no_albums_found_hint),
                             style = MaterialTheme.typography.bodyMedium,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                             textAlign = TextAlign.Center,

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/ArtistDetailScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/ArtistDetailScreen.kt
@@ -147,9 +147,9 @@ fun ArtistDetailScreen(
                 ) {
                     items(state.albums, key = { it.id.toString() }) { album ->
                         ExpressiveMediaCard(
-                            title = album.name ?: "",
-                            subtitle = album.productionYear?.toString() ?: "",
-                            imageUrl = mainViewModel.getImageUrl(album) ?: "",
+                            title = album.name.orEmpty(),
+                            subtitle = album.productionYear?.toString().orEmpty(),
+                            imageUrl = mainViewModel.getImageUrl(album).orEmpty(),
                             onCardClick = { onAlbumClick(album) },
                         )
                     }

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/ArtistDetailScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/ArtistDetailScreen.kt
@@ -1,24 +1,39 @@
 package com.rpeters.jellyfin.ui.screens
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Album
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.rpeters.jellyfin.OptInAppExperimentalApis
+import com.rpeters.jellyfin.R
 import com.rpeters.jellyfin.ui.components.ExpressiveBackNavigationIcon
+import com.rpeters.jellyfin.ui.components.ExpressiveCircularLoading
+import com.rpeters.jellyfin.ui.components.ExpressiveContentCard
 import com.rpeters.jellyfin.ui.components.ExpressiveMediaCard
 import com.rpeters.jellyfin.ui.components.ExpressiveTopAppBar
+import com.rpeters.jellyfin.ui.theme.MusicGreen
 import com.rpeters.jellyfin.ui.viewmodel.ArtistAlbumsViewModel
 import com.rpeters.jellyfin.ui.viewmodel.MainAppViewModel
 import org.jellyfin.sdk.model.api.BaseItemDto
@@ -49,22 +64,96 @@ fun ArtistDetailScreen(
             )
         },
     ) { padding ->
-        LazyVerticalGrid(
-            columns = GridCells.Adaptive(160.dp),
-            contentPadding = PaddingValues(16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(padding),
-        ) {
-            items(state.albums, key = { it.id.toString() }) { album ->
-                ExpressiveMediaCard(
-                    title = album.name ?: "",
-                    subtitle = album.productionYear?.toString() ?: "",
-                    imageUrl = mainViewModel.getImageUrl(album) ?: "",
-                    onCardClick = { onAlbumClick(album) },
-                )
+        when {
+            state.isLoading -> {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(padding),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    ExpressiveCircularLoading(
+                        size = 48.dp,
+                        showPulse = true,
+                    )
+                }
+            }
+
+            state.errorMessage != null -> {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(padding),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    ExpressiveContentCard(
+                        containerColor = MaterialTheme.colorScheme.errorContainer,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp),
+                    ) {
+                        Text(
+                            text = state.errorMessage ?: stringResource(R.string.unknown_error),
+                            color = MaterialTheme.colorScheme.onErrorContainer,
+                            style = MaterialTheme.typography.bodyMedium,
+                            modifier = Modifier.padding(16.dp),
+                            textAlign = TextAlign.Center,
+                        )
+                    }
+                }
+            }
+
+            state.albums.isEmpty() -> {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(padding),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(16.dp),
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Album,
+                            contentDescription = null,
+                            modifier = Modifier.padding(32.dp),
+                            tint = MusicGreen.copy(alpha = 0.6f),
+                        )
+                        Text(
+                            text = "No albums found",
+                            style = MaterialTheme.typography.headlineSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        Text(
+                            text = "This artist doesn't have any albums in your library yet",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            textAlign = TextAlign.Center,
+                        )
+                    }
+                }
+            }
+
+            else -> {
+                LazyVerticalGrid(
+                    columns = GridCells.Adaptive(160.dp),
+                    contentPadding = PaddingValues(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(padding),
+                ) {
+                    items(state.albums, key = { it.id.toString() }) { album ->
+                        ExpressiveMediaCard(
+                            title = album.name ?: "",
+                            subtitle = album.productionYear?.toString() ?: "",
+                            imageUrl = mainViewModel.getImageUrl(album) ?: "",
+                            onCardClick = { onAlbumClick(album) },
+                        )
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/MusicScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/MusicScreen.kt
@@ -158,7 +158,7 @@ fun MusicScreen(
     // Track scroll position so the filter/playback header can auto-hide, mirroring the
     // immersive screens' auto-hide top bar behavior.
     val gridState = rememberLazyGridState()
-    val headerVisible = rememberAutoHideTopBarVisible(gridState = gridState, nearTopOffsetPx = 0)
+    val headerVisible = rememberAutoHideTopBarVisible(gridState = gridState)
     val globalNavBarVisible = LocalNavBarVisible.current
     LaunchedEffect(headerVisible) { globalNavBarVisible.value = headerVisible }
 

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/MusicScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/MusicScreen.kt
@@ -1,11 +1,15 @@
 package com.rpeters.jellyfin.ui.screens
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.animation.expandVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -16,8 +20,10 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -77,6 +83,8 @@ import com.rpeters.jellyfin.ui.components.ExpressivePullToRefreshBox
 import com.rpeters.jellyfin.ui.components.ExpressiveTopAppBar
 import com.rpeters.jellyfin.ui.components.ExpressiveTopAppBarAction
 import com.rpeters.jellyfin.ui.components.ExpressiveWavyLinearProgress
+import com.rpeters.jellyfin.ui.components.immersive.rememberAutoHideTopBarVisible
+import com.rpeters.jellyfin.ui.navigation.LocalNavBarVisible
 import com.rpeters.jellyfin.ui.theme.MusicGreen
 import com.rpeters.jellyfin.ui.utils.EnhancedPlaybackUtils
 import com.rpeters.jellyfin.ui.utils.ShareUtils
@@ -146,6 +154,13 @@ fun MusicScreen(
     var viewMode by remember { mutableStateOf(MusicViewMode.GRID) }
     var showSortMenu by remember { mutableStateOf(false) }
     val context = LocalContext.current
+
+    // Track scroll position so the filter/playback header can auto-hide, mirroring the
+    // immersive screens' auto-hide top bar behavior.
+    val gridState = rememberLazyGridState()
+    val headerVisible = rememberAutoHideTopBarVisible(gridState = gridState, nearTopOffsetPx = 0)
+    val globalNavBarVisible = LocalNavBarVisible.current
+    LaunchedEffect(headerVisible) { globalNavBarVisible.value = headerVisible }
 
     // Get music items via unified loader and enrich with recent audio
     // Don't use remember() here - we want fresh data on every recomposition
@@ -315,74 +330,78 @@ fun MusicScreen(
                 Column(
                     modifier = Modifier.fillMaxSize(),
                 ) {
-                    MusicHeroPanel(
-                        totalCount = filteredAndSortedMusic.size,
-                        selectedFilter = selectedFilter,
-                        sortOrder = sortOrder,
-                    )
-
-                    if (playbackState.isConnected && (playbackState.currentMediaItem != null || playbackQueue.isNotEmpty())) {
-                        ActivePlaybackPanel(
-                            modifier = Modifier
-                                .padding(horizontal = 16.dp, vertical = 8.dp)
-                                .fillMaxWidth(),
-                            playbackState = playbackState,
-                            playbackQueue = playbackQueue,
-                            onShuffleClick = audioPlaybackViewModel::toggleShuffle,
-                            onPlayPauseClick = audioPlaybackViewModel::togglePlayPause,
-                            onSkipNextClick = audioPlaybackViewModel::skipToNext,
-                        )
-                    }
-
-                    LazyRow(
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                    // Auto-hides on scroll down, reappears on scroll up (mirrors the immersive
+                    // screens' auto-hide top bar behavior) so the list gets more room to breathe.
+                    AnimatedVisibility(
+                        visible = headerVisible,
+                        enter = expandVertically() + fadeIn(),
+                        exit = shrinkVertically() + fadeOut(),
                     ) {
-                        items(
-                            items = MusicFilter.getAllFilters(),
-                            key = { it },
-                            contentType = { "music_filter" },
-                        ) { filter ->
-                            FilterChip(
-                                onClick = { selectedFilter = filter },
-                                label = { Text(stringResource(id = filter.displayNameResId)) },
-                                selected = selectedFilter == filter,
-                                leadingIcon = when (filter) {
-                                    MusicFilter.FAVORITES -> {
-                                        {
-                                            Icon(
-                                                imageVector = Icons.Default.Star,
-                                                contentDescription = null,
-                                                modifier = Modifier.padding(2.dp),
-                                            )
-                                        }
-                                    }
-                                    MusicFilter.ALBUMS -> {
-                                        {
-                                            Icon(
-                                                imageVector = Icons.Default.Album,
-                                                contentDescription = null,
-                                                modifier = Modifier.padding(2.dp),
-                                            )
-                                        }
-                                    }
-                                    MusicFilter.ARTISTS -> {
-                                        {
-                                            Icon(
-                                                imageVector = Icons.Default.Person,
-                                                contentDescription = null,
-                                                modifier = Modifier.padding(2.dp),
-                                            )
-                                        }
-                                    }
-                                    else -> null
-                                },
-                                colors = FilterChipDefaults.filterChipColors(
-                                    selectedContainerColor = MusicGreen.copy(alpha = 0.18f),
-                                    selectedLabelColor = MusicGreen,
-                                    selectedLeadingIconColor = MusicGreen,
-                                ),
-                            )
+                        Column {
+                            if (playbackState.isConnected && (playbackState.currentMediaItem != null || playbackQueue.isNotEmpty())) {
+                                ActivePlaybackPanel(
+                                    modifier = Modifier
+                                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                                        .fillMaxWidth(),
+                                    playbackState = playbackState,
+                                    playbackQueue = playbackQueue,
+                                    onShuffleClick = audioPlaybackViewModel::toggleShuffle,
+                                    onPlayPauseClick = audioPlaybackViewModel::togglePlayPause,
+                                    onSkipNextClick = audioPlaybackViewModel::skipToNext,
+                                )
+                            }
+
+                            LazyRow(
+                                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                            ) {
+                                items(
+                                    items = MusicFilter.getAllFilters(),
+                                    key = { it },
+                                    contentType = { "music_filter" },
+                                ) { filter ->
+                                    FilterChip(
+                                        onClick = { selectedFilter = filter },
+                                        label = { Text(stringResource(id = filter.displayNameResId)) },
+                                        selected = selectedFilter == filter,
+                                        leadingIcon = when (filter) {
+                                            MusicFilter.FAVORITES -> {
+                                                {
+                                                    Icon(
+                                                        imageVector = Icons.Default.Star,
+                                                        contentDescription = null,
+                                                        modifier = Modifier.padding(2.dp),
+                                                    )
+                                                }
+                                            }
+                                            MusicFilter.ALBUMS -> {
+                                                {
+                                                    Icon(
+                                                        imageVector = Icons.Default.Album,
+                                                        contentDescription = null,
+                                                        modifier = Modifier.padding(2.dp),
+                                                    )
+                                                }
+                                            }
+                                            MusicFilter.ARTISTS -> {
+                                                {
+                                                    Icon(
+                                                        imageVector = Icons.Default.Person,
+                                                        contentDescription = null,
+                                                        modifier = Modifier.padding(2.dp),
+                                                    )
+                                                }
+                                            }
+                                            else -> null
+                                        },
+                                        colors = FilterChipDefaults.filterChipColors(
+                                            selectedContainerColor = MusicGreen.copy(alpha = 0.18f),
+                                            selectedLabelColor = MusicGreen,
+                                            selectedLeadingIconColor = MusicGreen,
+                                        ),
+                                    )
+                                }
+                            }
                         }
                     }
 
@@ -461,59 +480,11 @@ fun MusicScreen(
                                 isLoadingMore = appState.isLoadingMore,
                                 hasMoreItems = appState.hasMoreItems,
                                 onLoadMore = { viewModel.loadMoreItems() },
+                                gridState = gridState,
                             )
                         }
                     }
                 }
-            }
-        }
-    }
-}
-
-@Composable
-private fun MusicHeroPanel(
-    totalCount: Int,
-    selectedFilter: MusicFilter,
-    sortOrder: MusicSortOrder,
-) {
-    ExpressiveBlurSurface(
-        modifier = Modifier
-            .padding(horizontal = 16.dp, vertical = 12.dp)
-            .fillMaxWidth()
-            .border(
-                1.dp,
-                MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.32f),
-                RoundedCornerShape(28.dp),
-            ),
-        shape = RoundedCornerShape(28.dp),
-        color = MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.8f),
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(18.dp),
-            verticalArrangement = Arrangement.spacedBy(14.dp),
-        ) {
-            Text(
-                text = "Your soundtrack",
-                style = MaterialTheme.typography.headlineSmall,
-                fontWeight = FontWeight.SemiBold,
-            )
-            Text(
-                text = "Browse albums, artists, and tracks with the same expressive playback surfaces used across the player.",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            FlowRow(
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                MusicStatChip("$totalCount items")
-                MusicStatChip(stringResource(id = selectedFilter.displayNameResId))
-                MusicStatChip(
-                    stringResource(id = sortOrder.displayNameResId),
-                    accent = MaterialTheme.colorScheme.primary,
-                )
             }
         }
     }
@@ -654,6 +625,7 @@ private fun MusicContent(
     hasMoreItems: Boolean,
     onLoadMore: () -> Unit,
     modifier: Modifier = Modifier,
+    gridState: LazyGridState = rememberLazyGridState(),
 ) {
     when (viewMode) {
         MusicViewMode.GRID -> {
@@ -663,6 +635,7 @@ private fun MusicContent(
                 verticalArrangement = Arrangement.spacedBy(16.dp),
                 horizontalArrangement = Arrangement.spacedBy(12.dp),
                 modifier = modifier.fillMaxSize(),
+                state = gridState,
             ) {
                 items(
                     items = musicItems,
@@ -699,6 +672,7 @@ private fun MusicContent(
                 contentPadding = PaddingValues(16.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp),
                 modifier = modifier.fillMaxSize(),
+                state = gridState,
             ) {
                 items(
                     items = musicItems,

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/NowPlayingScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/NowPlayingScreen.kt
@@ -218,7 +218,10 @@ private fun AlbumArtSection(
 ) {
     Box(
         modifier = modifier.fillMaxWidth(),
-        contentAlignment = Alignment.Center,
+        // Anchor the artwork to the bottom of its weighted region (just above the track
+        // info) instead of centering it in the full leftover space above the fixed-height
+        // sections below — centering here made the art sit too close to the top bar.
+        contentAlignment = Alignment.BottomCenter,
     ) {
         Box(
             modifier = Modifier

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -199,6 +199,10 @@
     <string name="no_music_found">No music found</string>
     <string name="adjust_music_filters_hint">Try adjusting your filters or refresh the library</string>
 
+    <!-- Artist Detail Screen -->
+    <string name="no_albums_found">No albums found</string>
+    <string name="no_albums_found_hint">This artist doesn\'t have any albums in your library yet</string>
+
     <!-- Home Videos Screen -->
     <string name="no_home_videos_found">No home videos found</string>
     <string name="adjust_home_videos_filters_hint">Try adjusting your filters or refresh the library</string>

--- a/app/src/test/java/com/rpeters/jellyfin/data/repository/JellyfinMediaRepositoryTest.kt
+++ b/app/src/test/java/com/rpeters/jellyfin/data/repository/JellyfinMediaRepositoryTest.kt
@@ -10,7 +10,6 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
-import io.mockk.secondArg
 import io.mockk.spyk
 import kotlinx.coroutines.test.runTest
 import org.jellyfin.sdk.api.client.ApiClient
@@ -340,7 +339,8 @@ class JellyfinMediaRepositoryTest {
         coEvery {
             sessionManager.executeWithAuth<List<BaseItemDto>?>(any(), any())
         } coAnswers {
-            val block = secondArg<suspend (JellyfinServer, ApiClient) -> List<BaseItemDto>?>()
+            @Suppress("UNCHECKED_CAST")
+            val block = invocation.args[1] as suspend (JellyfinServer, ApiClient) -> List<BaseItemDto>?
             block(testServer, apiClient)
         }
 

--- a/app/src/test/java/com/rpeters/jellyfin/data/repository/JellyfinMediaRepositoryTest.kt
+++ b/app/src/test/java/com/rpeters/jellyfin/data/repository/JellyfinMediaRepositoryTest.kt
@@ -1,15 +1,20 @@
 package com.rpeters.jellyfin.data.repository
 
+import com.rpeters.jellyfin.data.JellyfinServer
 import com.rpeters.jellyfin.data.cache.JellyfinCache
 import com.rpeters.jellyfin.data.repository.common.ApiResult
 import com.rpeters.jellyfin.data.session.JellyfinSessionManager
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
+import io.mockk.secondArg
 import io.mockk.spyk
 import kotlinx.coroutines.test.runTest
 import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.extensions.itemsApi
 import org.jellyfin.sdk.api.operations.ItemsApi
 import org.jellyfin.sdk.model.api.BaseItemDto
@@ -19,6 +24,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import java.util.UUID
 
 class JellyfinMediaRepositoryTest {
 
@@ -294,5 +300,104 @@ class JellyfinMediaRepositoryTest {
         val errorResult = result as ApiResult.Error<List<BaseItemDto>>
         assertEquals(errorMessage, errorResult.message)
         assertEquals(com.rpeters.jellyfin.data.repository.common.ErrorType.NETWORK, errorResult.errorType)
+    }
+
+    // ========== getAlbumsForArtist regression tests (GitHub issue #1194) ==========
+    //
+    // MusicArtist entities in Jellyfin are virtual/aggregated - they are NOT the literal
+    // folder parent of MusicAlbum items, so querying with `parentId` always returned zero
+    // albums. The fix queries with `artistIds` + `recursive = true` instead. Unlike the
+    // tests above (which stub the repository method itself via `spyk`, never exercising the
+    // real method body), this test drives the REAL `getAlbumsForArtist()` implementation so
+    // the actual `ItemsApi.getItems(...)` call arguments can be verified with `coVerify`.
+
+    @Test
+    fun `getAlbumsForArtist queries itemsApi with artistIds and recursive, not parentId`() = runTest {
+        // Given
+        val artistId = "550e8400-e29b-41d4-a716-446655440000"
+        val artistUuid = UUID.fromString(artistId)
+        val userId = "11111111-1111-1111-1111-111111111111"
+        val userUuid = UUID.fromString(userId)
+
+        val testServer = JellyfinServer(
+            id = "server-1",
+            name = "Test Server",
+            url = "https://demo.jellyfin.org",
+            isConnected = true,
+            userId = userId,
+            username = "test-user",
+            accessToken = "test-access-token",
+        )
+
+        // Wire authRepository so BaseJellyfinRepository.validateServer() /
+        // validateTokenAndRefreshIfNeeded() resolve to our test server without reauthenticating.
+        every { authRepository.getCurrentServer() } returns testServer
+        every { authRepository.isTokenExpired() } returns false
+
+        // Wire sessionManager.executeWithAuth(...) - called internally by
+        // BaseJellyfinRepository.executeWithClient() - to invoke the real operation block with
+        // our mocked ApiClient, so the real getAlbumsForArtist() body actually runs.
+        coEvery {
+            sessionManager.executeWithAuth<List<BaseItemDto>?>(any(), any())
+        } coAnswers {
+            val block = secondArg<suspend (JellyfinServer, ApiClient) -> List<BaseItemDto>?>()
+            block(testServer, apiClient)
+        }
+
+        val mockAlbums = listOf(
+            mockk<BaseItemDto> {
+                coEvery { id } returns UUID.randomUUID()
+                coEvery { name } returns "Test Album"
+                coEvery { type } returns BaseItemKind.MUSIC_ALBUM
+            },
+        )
+        val queryResult = mockk<BaseItemDtoQueryResult> {
+            coEvery { items } returns mockAlbums
+            coEvery { totalRecordCount } returns mockAlbums.size
+        }
+
+        // Permissive stub: matches any argument shape so the "when" step always succeeds.
+        // Correctness of the actual query is asserted purely via coVerify below.
+        coEvery {
+            itemsApi.getItems(
+                userId = any(),
+                artistIds = any(),
+                recursive = any(),
+                parentId = any(),
+                includeItemTypes = any(),
+                sortBy = any(),
+                sortOrder = any(),
+                fields = any(),
+            )
+        } returns Response(queryResult, 200, emptyMap())
+
+        // Use a real (non-spyk) repository instance so getAlbumsForArtist()'s actual method
+        // body executes instead of being stubbed away.
+        val realRepository = JellyfinMediaRepository(authRepository, sessionManager, cache, healthChecker)
+
+        // When
+        val result = realRepository.getAlbumsForArtist(artistId)
+
+        // Then
+        assertTrue(result is ApiResult.Success<List<BaseItemDto>>)
+        val successResult = result as ApiResult.Success<List<BaseItemDto>>
+        assertEquals(1, successResult.data.size)
+        assertEquals("Test Album", successResult.data[0].name)
+
+        // Regression guard: must query by artistIds + recursive = true, and must NOT scope
+        // the query by parentId (that was the bug behind issue #1194 - MusicArtist is not the
+        // literal folder parent of its MusicAlbum items).
+        coVerify(exactly = 1) {
+            itemsApi.getItems(
+                userId = userUuid,
+                artistIds = listOf(artistUuid),
+                recursive = true,
+                parentId = null,
+                includeItemTypes = listOf(BaseItemKind.MUSIC_ALBUM),
+                sortBy = any(),
+                sortOrder = any(),
+                fields = any(),
+            )
+        }
     }
 }


### PR DESCRIPTION
## Summary

This PR enhances the Music screen with an auto-hiding filter/playback header that mirrors the immersive screens' top bar behavior, improving content visibility during scrolling. It also adds comprehensive loading, error, and empty states to the Artist Detail screen, and fixes a critical bug in artist album fetching.

**Key changes:**
- Music screen: Implement auto-hide header using `AnimatedVisibility` with scroll-aware state tracking
- Artist Detail screen: Add loading spinner, error card, and empty state UI
- Fix artist album query to use `artistIds` parameter instead of `parentId` (Jellyfin virtual entity issue)
- Improve NowPlaying screen layout by anchoring album art to bottom instead of centering
- Fix status bar inset handling in detail screens to prevent double gaps

## Type of change

- [x] feat (new feature)
- [x] fix (bug fix)
- [x] refactor (no functional change)

## Affected areas

**MusicScreen.kt:**
- Removed `MusicHeroPanel` composable (hero section with stats)
- Wrapped filter chips and playback panel in `AnimatedVisibility` with auto-hide logic
- Added `gridState` tracking via `rememberLazyGridState()` and `rememberAutoHideTopBarVisible()`
- Connected header visibility to global nav bar state via `LocalNavBarVisible`
- Passed `gridState` to `MusicContent` for both grid and list view modes

**ArtistDetailScreen.kt:**
- Added loading state with `ExpressiveCircularLoading`
- Added error state with styled error card
- Added empty state with icon and descriptive message
- Wrapped grid content in `when` expression for state handling

**JellyfinMediaRepository.kt:**
- Fixed `getAlbumsForArtist()` to use `artistIds` parameter instead of `parentId`
- Added `recursive = true` to match Jellyfin web client and Finamp behavior
- Added explanatory comment about virtual MusicArtist entities

**JellyfinApp.kt:**
- Set `contentWindowInsets = WindowInsets(0, 0, 0, 0)` on outer Scaffold for detail screens
- Prevents double status bar inset gaps when detail screens have their own Scaffold

**NowPlayingScreen.kt:**
- Changed album art alignment from `Alignment.Center` to `Alignment.BottomCenter`
- Anchors artwork to bottom of weighted region instead of centering in full space

## Testing

- Verify Music screen header auto-hides on scroll down and reappears on scroll up
- Verify Artist Detail screen shows loading spinner while fetching albums
- Verify Artist Detail screen displays error card on API failure
- Verify Artist Detail screen shows empty state when artist has no albums
- Verify artist albums now load correctly (previously returned empty due to parentId bug)
- Verify NowPlaying album art positioning looks correct relative to track info
- Verify no double status bar gaps on detail screens

https://claude.ai/code/session_01NuGBAZvHZJqupAQLgDCbfm