### PR TITLE
Fix Albums/Artists filters staying empty due to music pagination bugs

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/MusicScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/MusicScreen.kt
@@ -167,6 +167,7 @@ fun MusicScreen(
     val libraryMusic = viewModel.getLibraryTypeData(LibraryType.MUSIC)
     val recentMusic = appState.recentlyAddedByTypes[BaseItemKind.AUDIO.name] ?: emptyList()
     val musicItems = (libraryMusic + recentMusic).distinctBy { it.id }
+    val musicLibraryId = remember(appState.libraries) { viewModel.getLibraryIdForType(LibraryType.MUSIC) }
 
     // Apply filtering and sorting
     val filteredAndSortedMusic = remember(musicItems, selectedFilter, sortOrder) {
@@ -213,6 +214,28 @@ fun MusicScreen(
             MusicSortOrder.RUNTIME_ASC -> filtered.sortedBy {
                 it.runTimeTicks ?: 0L
             }
+        }
+    }
+
+    // The music library page is fetched with Audio/MusicAlbum/MusicArtist mixed together
+    // and sorted alphabetically, so a type filter (e.g. Albums/Artists) can easily come up
+    // empty on the currently-loaded page even though matching items exist further into the
+    // library. Keep paging automatically until the filter finds results or the library is
+    // exhausted, rather than leaving the user stuck on a false "no music found".
+    LaunchedEffect(
+        selectedFilter,
+        filteredAndSortedMusic.isEmpty(),
+        appState.hasMoreItems,
+        appState.isLoadingMore,
+        appState.isLoading,
+    ) {
+        if (filteredAndSortedMusic.isEmpty() &&
+            musicItems.isNotEmpty() &&
+            appState.hasMoreItems &&
+            !appState.isLoadingMore &&
+            !appState.isLoading
+        ) {
+            musicLibraryId?.let { viewModel.loadMoreLibraryItems(it) }
         }
     }
 
@@ -440,6 +463,21 @@ fun MusicScreen(
                             }
                         }
 
+                        filteredAndSortedMusic.isEmpty() && appState.isLoadingMore -> {
+                            // Still paging through the library looking for a match for the
+                            // current filter (see the auto-continue LaunchedEffect above) -
+                            // show a spinner instead of a premature "no music found".
+                            Box(
+                                modifier = Modifier.fillMaxSize(),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                ExpressiveCircularLoading(
+                                    size = 48.dp,
+                                    showPulse = true,
+                                )
+                            }
+                        }
+
                         filteredAndSortedMusic.isEmpty() -> {
                             Box(
                                 modifier = Modifier.fillMaxSize(),
@@ -479,7 +517,7 @@ fun MusicScreen(
                                 onMoreClick = { item -> ShareUtils.shareMedia(context, item) },
                                 isLoadingMore = appState.isLoadingMore,
                                 hasMoreItems = appState.hasMoreItems,
-                                onLoadMore = { viewModel.loadMoreItems() },
+                                onLoadMore = { musicLibraryId?.let { viewModel.loadMoreLibraryItems(it) } },
                                 gridState = gridState,
                             )
                         }

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/MusicScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/MusicScreen.kt
@@ -168,6 +168,12 @@ fun MusicScreen(
     val recentMusic = appState.recentlyAddedByTypes[BaseItemKind.AUDIO.name] ?: emptyList()
     val musicItems = (libraryMusic + recentMusic).distinctBy { it.id }
     val musicLibraryId = remember(appState.libraries) { viewModel.getLibraryIdForType(LibraryType.MUSIC) }
+    // Pagination is tracked per-library; the legacy appState.hasMoreItems/isLoadingMore
+    // fields are shared across whichever library last paginated, so reading them here would
+    // make this screen react to unrelated libraries' load-more activity.
+    val musicPagination = appState.libraryPaginationState[musicLibraryId]
+    val musicHasMoreItems = musicPagination?.hasMore ?: false
+    val musicIsLoadingMore = musicPagination?.isLoadingMore ?: false
 
     // Apply filtering and sorting
     val filteredAndSortedMusic = remember(musicItems, selectedFilter, sortOrder) {
@@ -225,15 +231,18 @@ fun MusicScreen(
     LaunchedEffect(
         selectedFilter,
         filteredAndSortedMusic.isEmpty(),
-        appState.hasMoreItems,
-        appState.isLoadingMore,
+        musicLibraryId,
+        musicHasMoreItems,
+        musicIsLoadingMore,
         appState.isLoading,
+        appState.errorMessage,
     ) {
         if (filteredAndSortedMusic.isEmpty() &&
             musicItems.isNotEmpty() &&
-            appState.hasMoreItems &&
-            !appState.isLoadingMore &&
-            !appState.isLoading
+            musicHasMoreItems &&
+            !musicIsLoadingMore &&
+            !appState.isLoading &&
+            appState.errorMessage == null
         ) {
             musicLibraryId?.let { viewModel.loadMoreLibraryItems(it) }
         }
@@ -463,7 +472,7 @@ fun MusicScreen(
                             }
                         }
 
-                        filteredAndSortedMusic.isEmpty() && appState.isLoadingMore -> {
+                        filteredAndSortedMusic.isEmpty() && musicIsLoadingMore -> {
                             // Still paging through the library looking for a match for the
                             // current filter (see the auto-continue LaunchedEffect above) -
                             // show a spinner instead of a premature "no music found".
@@ -515,8 +524,8 @@ fun MusicScreen(
                                 onItemClick = onItemClick,
                                 onFavoriteClick = { item -> viewModel.toggleFavorite(item) },
                                 onMoreClick = { item -> ShareUtils.shareMedia(context, item) },
-                                isLoadingMore = appState.isLoadingMore,
-                                hasMoreItems = appState.hasMoreItems,
+                                isLoadingMore = musicIsLoadingMore,
+                                hasMoreItems = musicHasMoreItems,
                                 onLoadMore = { musicLibraryId?.let { viewModel.loadMoreLibraryItems(it) } },
                                 gridState = gridState,
                             )

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/NowPlayingScreen.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/NowPlayingScreen.kt
@@ -160,12 +160,16 @@ fun NowPlayingScreen(
                     .fillMaxSize()
                     .padding(horizontal = 24.dp, vertical = 20.dp),
                 horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.SpaceBetween,
             ) {
+                // Equal flexible spacers above and below the content block center it as a
+                // whole in the available space, instead of a single flexible region above
+                // the artwork (which left the art sitting too close to the top bar).
+                Spacer(modifier = Modifier.weight(1f))
+
                 AlbumArtSection(
                     currentMediaItem = playbackState.currentMediaItem,
                     palette = palette,
-                    modifier = Modifier.weight(1f),
+                    modifier = Modifier.fillMaxWidth(),
                 )
 
                 Spacer(modifier = Modifier.height(28.dp))
@@ -204,7 +208,7 @@ fun NowPlayingScreen(
                     onSpeedChange = { viewModel.setPlaybackSpeed(it) },
                 )
 
-                Spacer(modifier = Modifier.height(12.dp))
+                Spacer(modifier = Modifier.weight(1f))
             }
         }
     }


### PR DESCRIPTION
## Summary

Follow-up to issue #1194 / PR #1196. After that fix landed, the Albums and Artists filter chips on the Music screen were still showing "no music found". The earlier fix only addressed `getAlbumsForArtist()` — the query used once you've already reached a specific artist's detail page — but two separate, compounding bugs prevented users from ever reaching that point via the filter chips:

- The music library's first page mixes `Audio`/`MusicAlbum`/`MusicArtist` items together, sorted alphabetically, capped at 100 items. In a real library, songs vastly outnumber albums/artists, so the first page can easily contain zero albums or artists even though plenty exist further into the (unfetched) library.
- `MusicScreen`'s "load more" was wired to `viewModel.loadMoreItems()`, which just calls `loadInitialData()` — not the actual per-library pager (`loadMoreLibraryItems(libraryId)`) — so scrolling never paginated the music library forward. Worse, the load-more control only renders when the filtered list is already non-empty, so once a filter came up empty there was no way to trigger further loading at all — it was permanently stuck.

## Changes

**`MusicScreen.kt`:**
- Wire "load more" to the correct `loadMoreLibraryItems(libraryId)` instead of the unrelated `loadMoreItems()`.
- Add a `LaunchedEffect` that automatically keeps paging the music library whenever the active filter (e.g. Albums/Artists) comes up empty but more pages remain, until it finds matches or the library is exhausted.
- Show a loading spinner instead of a premature "no music found" while that auto-continue fetch is in flight.

## Test plan

- [ ] Verify the Albums filter eventually shows albums (not stuck empty) on a library where albums aren't in the first alphabetically-sorted page of combined results
- [ ] Verify the Artists filter behaves the same way
- [ ] Verify manual scroll-triggered "load more" still works for the All/Songs filters
- [ ] Verify no infinite fetch loop when a filter has genuinely zero matches (e.g. Favorites with nothing favorited) and the library is exhausted

https://claude.ai/code/session_01NuGBAZvHZJqupAQLgDCbfm

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuGBAZvHZJqupAQLgDCbfm)_