### PR TITLE
fix: Replace FlowRow with manual Column/Row to fix library card layout

### DIFF
--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/home/ImmersiveHomeSections.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/home/ImmersiveHomeSections.kt
@@ -234,23 +234,39 @@ private fun LibraryNavigationCarousel(
         // Display libraries in a 2-column grid so all cards are fully visible.
         // HorizontalUncontainedCarousel is intentionally avoided here because it
         // clips the last visible card, causing the "Shows card cut off" issue.
-        FlowRow(
+        //
+        // A manually chunked Row/Column is used instead of FlowRow.weight() because
+        // FlowRowScope.weight() requires intrinsic measurements of its children, and
+        // LibraryExpressiveCard's content (HeroImageWithGradient) contains
+        // BoxWithConstraints/SubcomposeAsyncImage, which are SubcomposeLayout-based and
+        // do not support intrinsic measurement. Combining the two crashes with
+        // "Asking for intrinsic measurements of SubcomposeLayout layouts is not
+        // supported." Plain RowScope.weight() does not require intrinsics, so it is safe.
+        Column(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
-            maxItemsInEachRow = 2,
         ) {
-            visibleLibraries.forEach { library ->
-                LibraryExpressiveCard(
-                    library = library,
-                    imageUrl = getImageUrl(library),
-                    onClick = { onLibraryClick(library) },
-                    modifier = Modifier
-                        .weight(1f)
-                        .height(160.dp),
-                )
+            visibleLibraries.chunked(2).forEach { rowLibraries ->
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    rowLibraries.forEach { library ->
+                        LibraryExpressiveCard(
+                            library = library,
+                            imageUrl = getImageUrl(library),
+                            onClick = { onLibraryClick(library) },
+                            modifier = Modifier
+                                .weight(1f)
+                                .height(160.dp),
+                        )
+                    }
+                    if (rowLibraries.size == 1) {
+                        Spacer(modifier = Modifier.weight(1f))
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/com/rpeters/jellyfin/ui/screens/home/ImmersiveHomeSections.kt
+++ b/app/src/main/java/com/rpeters/jellyfin/ui/screens/home/ImmersiveHomeSections.kt
@@ -14,6 +14,7 @@ import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -215,7 +216,7 @@ internal fun MobileExpressiveHomeContent(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun LibraryNavigationCarousel(
     libraries: List<BaseItemDto>,
@@ -254,14 +255,16 @@ private fun LibraryNavigationCarousel(
                     horizontalArrangement = Arrangement.spacedBy(12.dp),
                 ) {
                     rowLibraries.forEach { library ->
-                        LibraryExpressiveCard(
-                            library = library,
-                            imageUrl = getImageUrl(library),
-                            onClick = { onLibraryClick(library) },
-                            modifier = Modifier
-                                .weight(1f)
-                                .height(160.dp),
-                        )
+                        key(library.id) {
+                            LibraryExpressiveCard(
+                                library = library,
+                                imageUrl = getImageUrl(library),
+                                onClick = { onLibraryClick(library) },
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .height(160.dp),
+                            )
+                        }
                     }
                     if (rowLibraries.size == 1) {
                         Spacer(modifier = Modifier.weight(1f))


### PR DESCRIPTION
## Summary

Replaces `FlowRow` with a manually chunked `Column`/`Row` layout in the library navigation carousel to fix a crash caused by intrinsic measurement incompatibility.

**Problem**: `FlowRow.weight()` requires intrinsic measurements of its children. `LibraryExpressiveCard` contains `HeroImageWithGradient`, which uses `BoxWithConstraints` and `SubcomposeAsyncImage` (both `SubcomposeLayout`-based). These layouts don't support intrinsic measurement, causing a crash: "Asking for intrinsic measurements of SubcomposeLayout layouts is not supported."

**Solution**: Manually chunk libraries into rows of 2 using `chunked(2)` and apply `weight()` at the `RowScope` level instead. Plain `RowScope.weight()` does not require intrinsic measurements, avoiding the crash while maintaining the 2-column grid layout.

**Changes**:
- Replace `FlowRow` with `Column` containing manually chunked `Row`s
- Each row displays up to 2 library cards with equal width via `weight(1f)`
- Add `Spacer` for odd-numbered library counts to maintain alignment
- Preserve horizontal and vertical spacing (12.dp)

## Type of change

- [x] fix (bug fix)

## How to test

```bash
# Build
./gradlew assembleDebug

# Run unit tests
./gradlew testDebugUnitTest

# Run lint
./gradlew lintDebug
```

Navigate to the home screen and verify:
1. Library cards display in a 2-column grid
2. All cards are fully visible (no clipping)
3. Odd number of libraries (e.g., 3, 5) display with proper alignment
4. No crashes occur when loading the home screen

## Checklist

- [x] Follows Conventional Commits
- [x] Branch named appropriately
- [x] No new tests needed (layout refactor with no functional behavior change)
- [x] `./gradlew lintDebug` passes

https://claude.ai/code/session_01XuiSZmWt4MnAi6mXQbb6bp